### PR TITLE
Introduce full inline text styling support.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ buildscript {
           layout: "androidx.ui:ui-layout:${versions.compose}",
           material: "androidx.ui:ui-material:${versions.compose}",
           test: "androidx.ui:ui-test:${versions.compose}",
+          text: "androidx.ui:ui-text:${versions.compose}",
           tooling: "androidx.ui:ui-tooling:${versions.compose}",
       ],
       kotlin: [

--- a/richtext-ui/build.gradle
+++ b/richtext-ui/build.gradle
@@ -8,4 +8,5 @@ dependencies {
 
   implementation deps.kotlin.stdlib
   implementation deps.compose.foundation
+  implementation deps.compose.text
 }

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/CodeBlock.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/CodeBlock.kt
@@ -36,7 +36,7 @@ data class CodeBlockStyle(
 private val DefaultCodeBlockTextStyle = TextStyle(
     fontFamily = FontFamily.Monospace
 )
-private val DefaultCodeBlockBackground: Color = Color.LightGray.copy(alpha = .5f)
+internal val DefaultCodeBlockBackground: Color = Color.LightGray.copy(alpha = .5f)
 private val DefaultCodeBlockPadding: TextUnit = 16.sp
 
 internal fun CodeBlockStyle.resolveDefaults() = CodeBlockStyle(

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/Demo.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/Demo.kt
@@ -16,6 +16,7 @@ import androidx.ui.tooling.preview.Preview
 import androidx.ui.unit.dp
 import com.zachklipp.richtext.ui.ListType.Ordered
 import com.zachklipp.richtext.ui.ListType.Unordered
+import com.zachklipp.richtext.ui.string.TextPreview
 
 @Preview(widthDp = 300, heightDp = 1000)
 @Composable fun RichTextDemoOnWhite() {
@@ -39,6 +40,7 @@ import com.zachklipp.richtext.ui.ListType.Unordered
     Text("Simple paragraph.")
     Text("Paragraph with\nmultiple lines.")
     Text("Paragraph with really long line that should be getting wrapped.")
+    TextPreview()
 
     Heading(0, "Lists")
     Heading(1, "Unordered")
@@ -53,7 +55,7 @@ import com.zachklipp.richtext.ui.ListType.Unordered
 
     Heading(0, "Code Block")
     CodeBlock(
-        """
+      """
         {
           "Hello": "world!"
         }
@@ -71,11 +73,11 @@ import com.zachklipp.richtext.ui.ListType.Unordered
 
     Heading(0, "Table")
     Table(
-        modifier = Modifier.fillMaxWidth(),
-        headerRow = {
-          cell { Text("Column 1") }
-          cell { Text("Column 2") }
-        }) {
+      modifier = Modifier.fillMaxWidth(),
+      headerRow = {
+        cell { Text("Column 1") }
+        cell { Text("Column 2") }
+      }) {
       row {
         cell { Text("Hello") }
         cell {
@@ -96,17 +98,17 @@ import com.zachklipp.richtext.ui.ListType.Unordered
 
 @Composable private fun RichTextScope.ListDemo(listType: ListType) {
   FormattedList(listType,
-      @Composable {
-        Text("First list item")
-        FormattedList(listType,
-            @Composable { Text("Indented 1") }
-        )
-      },
-      @Composable {
-        Text("Second list item.")
-        FormattedList(listType,
-            @Composable { Text("Indented 2") }
-        )
-      }
+    @Composable {
+      Text("First list item")
+      FormattedList(listType,
+        @Composable { Text("Indented 1") }
+      )
+    },
+    @Composable {
+      Text("Second list item.")
+      FormattedList(listType,
+        @Composable { Text("Indented 2") }
+      )
+    }
   )
 }

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/RichTextStyle.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/RichTextStyle.kt
@@ -4,6 +4,7 @@ import androidx.compose.Immutable
 import androidx.compose.ambientOf
 import androidx.ui.unit.TextUnit
 import androidx.ui.unit.sp
+import com.zachklipp.richtext.ui.string.RichTextStringStyle
 
 internal val RichTextStyleAmbient = ambientOf { RichTextStyle.Default }
 
@@ -19,7 +20,8 @@ data class RichTextStyle(
   val listStyle: ListStyle? = null,
   val blockQuoteGutter: BlockQuoteGutter? = null,
   val codeBlockStyle: CodeBlockStyle? = null,
-  val tableStyle: TableStyle? = null
+  val tableStyle: TableStyle? = null,
+  val stringStyle: RichTextStringStyle? = null
 ) {
   companion object {
     val Default = RichTextStyle()
@@ -32,7 +34,8 @@ fun RichTextStyle.merge(otherStyle: RichTextStyle?): RichTextStyle = RichTextSty
     listStyle = otherStyle?.listStyle ?: listStyle,
     blockQuoteGutter = otherStyle?.blockQuoteGutter ?: blockQuoteGutter,
     codeBlockStyle = otherStyle?.codeBlockStyle ?: codeBlockStyle,
-    tableStyle = otherStyle?.tableStyle ?: tableStyle
+    tableStyle = otherStyle?.tableStyle ?: tableStyle,
+    stringStyle = stringStyle?.merge(otherStyle?.stringStyle)
 )
 
 fun RichTextStyle.resolveDefaults(): RichTextStyle = RichTextStyle(
@@ -41,5 +44,6 @@ fun RichTextStyle.resolveDefaults(): RichTextStyle = RichTextStyle(
     listStyle = (listStyle ?: ListStyle.Default).resolveDefaults(),
     blockQuoteGutter = blockQuoteGutter ?: DefaultBlockQuoteGutter,
     codeBlockStyle = (codeBlockStyle ?: CodeBlockStyle.Default).resolveDefaults(),
-    tableStyle = (tableStyle ?: TableStyle.Default).resolveDefaults()
+    tableStyle = (tableStyle ?: TableStyle.Default).resolveDefaults(),
+    stringStyle = (stringStyle ?: RichTextStringStyle.Default).resolveDefaults()
 )

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/string/InlineContent.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/string/InlineContent.kt
@@ -1,0 +1,103 @@
+@file:Suppress("RemoveEmptyParenthesesFromAnnotationEntry", "FunctionName")
+
+package com.zachklipp.richtext.ui.string
+
+import androidx.compose.Composable
+import androidx.compose.StructurallyEqual
+import androidx.compose.getValue
+import androidx.compose.setValue
+import androidx.compose.state
+import androidx.ui.core.Constraints
+import androidx.ui.core.DensityAmbient
+import androidx.ui.core.Layout
+import androidx.ui.geometry.Size
+import androidx.ui.text.InlineTextContent
+import androidx.ui.text.Placeholder
+import androidx.ui.text.PlaceholderVerticalAlign.AboveBaseline
+import androidx.ui.unit.Density
+import androidx.ui.unit.px
+import androidx.ui.unit.sp
+import androidx.ui.unit.toPx
+
+/**
+ * A Composable that can be embedded inline in a [RichTextString] by passing to
+ * [RichTextString.Builder.appendInlineContent].
+ *
+ * @param initialSize Optional function to calculate the initial size of the content. Not specifying
+ * this may cause flicker.
+ */
+class InlineContent(
+  internal val initialSize: (Density.() -> Size)? = null,
+  internal val content: @Composable() Density.(alternateText: String) -> Unit
+)
+
+/**
+ * Converts a map of [InlineContent]s into a map of [InlineTextContent] that is ready to pass to
+ * the core Text composable. Whenever any of the contents resize themselves, or if the map changes,
+ * a new map will be returned with updated [Placeholder]s.
+ */
+@Composable internal fun ManageInlineTextContents(
+  inlineContents: Map<String, InlineContent>,
+  textConstraints: () -> Constraints,
+  forceTextRelayout: () -> Unit
+): Map<String, InlineTextContent> {
+  val density = DensityAmbient.current
+
+  // The content must fit inside the text's max bounds, but can be as small as it wants.
+  val contentConstraints = fun(): Constraints = textConstraints().let {
+    Constraints(maxWidth = it.maxWidth, maxHeight = it.maxHeight)
+  }
+
+  return inlineContents.mapValues { (_, content) ->
+    ReifyInlineContent(
+      content,
+      contentConstraints,
+      density,
+      forceTextRelayout
+    )
+  }
+}
+
+/**
+ * Given an [InlineContent] function, wraps it in a [InlineTextContent] that will allow the content
+ * to measure itself inside the enclosing layout's maximum constraints, and automatically return a
+ * new [InlineTextContent] whenever the content changes size to update how much space is reserved
+ * in the text layout for the content.
+ */
+@Composable private fun ReifyInlineContent(
+  content: InlineContent,
+  contentConstraints: () -> Constraints,
+  density: Density,
+  forceTextRelayout: () -> Unit
+): InlineTextContent {
+  var size by state(StructurallyEqual) { content.initialSize?.invoke(density) }
+
+  with(density) {
+    // If size is null, content hasn't been measured yet, so just draw with zero width for now.
+    // Set the height to 1 em so we can calculate how many pixels in an EM.
+    val placeholder = Placeholder(
+      width = size?.width?.toSp() ?: 0.sp,
+      height = size?.height?.toSp() ?: 1.sp,
+      placeholderVerticalAlign = AboveBaseline
+    )
+
+    return InlineTextContent(placeholder) { alternateText ->
+      Layout(children = { content.content(this, alternateText) }) { measurables, _, _ ->
+        // Measure the content with the constraints for the parent Text layout, not the actual.
+        // This allows it to determine exactly how large it needs to be so we can update the
+        // placeholder.
+        val contentPlaceable = measurables.single().measure(contentConstraints())
+        if (contentPlaceable.width.toPx().value != size?.width
+          || contentPlaceable.height.toPx().value != size?.height
+        ) {
+          size = Size(contentPlaceable.width.toPx().value, contentPlaceable.height.toPx().value)
+          forceTextRelayout()
+        }
+
+        layout(contentPlaceable.width, contentPlaceable.height) {
+          contentPlaceable.place(0.px, 0.px)
+        }
+      }
+    }
+  }
+}

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/string/RichTextString.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/string/RichTextString.kt
@@ -1,0 +1,321 @@
+@file:Suppress("RemoveEmptyParenthesesFromAnnotationEntry", "SuspiciousCollectionReassignment")
+
+package com.zachklipp.richtext.ui.string
+
+import androidx.compose.Immutable
+import androidx.ui.graphics.Color
+import androidx.ui.text.AnnotatedString
+import androidx.ui.text.SpanStyle
+import androidx.ui.text.annotatedString
+import androidx.ui.text.appendInlineContent
+import androidx.ui.text.font.FontFamily
+import androidx.ui.text.font.FontStyle
+import androidx.ui.text.font.FontWeight
+import androidx.ui.text.length
+import androidx.ui.text.style.BaselineShift
+import androidx.ui.text.style.TextDecoration
+import androidx.ui.unit.sp
+import com.zachklipp.richtext.ui.DefaultCodeBlockBackground
+import com.zachklipp.richtext.ui.string.RichTextString.Builder
+import com.zachklipp.richtext.ui.string.RichTextString.Format
+import com.zachklipp.richtext.ui.string.RichTextString.Format.Bold
+import com.zachklipp.richtext.ui.string.RichTextString.Format.Code
+import com.zachklipp.richtext.ui.string.RichTextString.Format.Companion.FormatAnnotationScope
+import com.zachklipp.richtext.ui.string.RichTextString.Format.Italic
+import com.zachklipp.richtext.ui.string.RichTextString.Format.Link
+import com.zachklipp.richtext.ui.string.RichTextString.Format.Strikethrough
+import com.zachklipp.richtext.ui.string.RichTextString.Format.Subscript
+import com.zachklipp.richtext.ui.string.RichTextString.Format.Superscript
+import com.zachklipp.richtext.ui.string.RichTextString.Format.Underline
+import java.util.UUID
+import kotlin.LazyThreadSafetyMode.NONE
+
+/** Copied from inline content. */
+@PublishedApi
+internal const val REPLACEMENT_CHAR = "\uFFFD"
+
+@Immutable
+data class RichTextStringStyle(
+  val boldStyle: SpanStyle? = null,
+  val italicStyle: SpanStyle? = null,
+  val underlineStyle: SpanStyle? = null,
+  val strikethroughStyle: SpanStyle? = null,
+  val subscriptStyle: SpanStyle? = null,
+  val superscriptStyle: SpanStyle? = null,
+  val codeStyle: SpanStyle? = null,
+  val linkStyle: SpanStyle? = null
+) {
+  internal fun merge(otherStyle: RichTextStringStyle?): RichTextStringStyle {
+    if (otherStyle == null) return this
+    return RichTextStringStyle(
+      boldStyle = boldStyle.merge(otherStyle.boldStyle),
+      italicStyle = italicStyle.merge(otherStyle.italicStyle),
+      underlineStyle = underlineStyle.merge(otherStyle.underlineStyle),
+      strikethroughStyle = strikethroughStyle.merge(otherStyle.strikethroughStyle),
+      subscriptStyle = subscriptStyle.merge(otherStyle.subscriptStyle),
+      superscriptStyle = superscriptStyle.merge(otherStyle.superscriptStyle),
+      codeStyle = codeStyle.merge(otherStyle.codeStyle),
+      linkStyle = linkStyle.merge(otherStyle.linkStyle)
+    )
+  }
+
+  internal fun resolveDefaults(): RichTextStringStyle =
+    RichTextStringStyle(
+      boldStyle = boldStyle ?: Bold.DefaultStyle,
+      italicStyle = italicStyle ?: Italic.DefaultStyle,
+      underlineStyle = underlineStyle ?: Underline.DefaultStyle,
+      strikethroughStyle = strikethroughStyle ?: Strikethrough.DefaultStyle,
+      subscriptStyle = subscriptStyle ?: Subscript.DefaultStyle,
+      superscriptStyle = superscriptStyle ?: Superscript.DefaultStyle,
+      codeStyle = codeStyle ?: Code.DefaultStyle,
+      linkStyle = linkStyle ?: Link.DefaultStyle
+    )
+
+  companion object {
+    val Default = RichTextStringStyle()
+
+    private fun SpanStyle?.merge(otherStyle: SpanStyle?): SpanStyle? =
+      this?.merge(otherStyle) ?: otherStyle
+  }
+}
+
+inline fun richTextString(builder: Builder.() -> Unit): RichTextString =
+  Builder().apply(builder)
+    .toRichTextString()
+
+/**
+ * TODO write documentation
+ */
+@Immutable
+data class RichTextString internal constructor(
+  private val taggedString: AnnotatedString,
+  internal val formatObjects: Map<String, Any>
+) {
+
+  val length: Int get() = taggedString.length
+  val text: String get() = taggedString.text
+
+  operator fun plus(other: RichTextString): RichTextString =
+    Builder(length + other.length).run {
+      append(this@RichTextString)
+      append(other)
+      toRichTextString()
+    }
+
+  internal fun toAnnotatedString(style: RichTextStringStyle, contentColor: Color): AnnotatedString =
+    annotatedString {
+      append(taggedString)
+
+      // Get all of our format annotations.
+      val tags = taggedString.getStringAnnotations(FormatAnnotationScope, 0, taggedString.length)
+      // And apply their actual SpanStyles to the string.
+      tags.forEach { range ->
+        val format = Format.findTag(range.item, formatObjects) ?: return@forEach
+        format.getStyle(style, contentColor)
+          ?.let { spanStyle -> addStyle(spanStyle, range.start, range.end) }
+      }
+    }
+
+  internal fun getInlineContents(): Map<String, InlineContent> =
+    formatObjects.asSequence()
+      .mapNotNull { (tag, format) ->
+        tag.removePrefix("inline:")
+          // If no prefix was found then we ignore it.
+          .takeUnless { it === tag }
+          ?.let {
+            @Suppress("UNCHECKED_CAST")
+            Pair(it, format as InlineContent)
+          }
+      }
+      .toMap()
+
+  sealed class Format(private val simpleTag: String? = null) {
+
+    internal open fun getStyle(
+      richTextStyle: RichTextStringStyle,
+      contentColor: Color
+    ): SpanStyle? = null
+
+    object Italic : Format("italic") {
+      internal val DefaultStyle = SpanStyle(fontStyle = FontStyle.Italic)
+      override fun getStyle(
+        richTextStyle: RichTextStringStyle,
+        contentColor: Color
+      ) = richTextStyle.italicStyle
+    }
+
+    object Bold : Format(simpleTag = "foo") {
+      internal val DefaultStyle = SpanStyle(fontWeight = FontWeight.Bold)
+      override fun getStyle(
+        richTextStyle: RichTextStringStyle,
+        contentColor: Color
+      ) = richTextStyle.boldStyle
+    }
+
+    object Underline : Format("underline") {
+      internal val DefaultStyle = SpanStyle(textDecoration = TextDecoration.Underline)
+      override fun getStyle(
+        richTextStyle: RichTextStringStyle,
+        contentColor: Color
+      ) = richTextStyle.underlineStyle
+    }
+
+    object Strikethrough : Format("strikethrough") {
+      internal val DefaultStyle = SpanStyle(textDecoration = TextDecoration.LineThrough)
+      override fun getStyle(
+        richTextStyle: RichTextStringStyle,
+        contentColor: Color
+      ) = richTextStyle.strikethroughStyle
+    }
+
+    object Subscript : Format("subscript") {
+      internal val DefaultStyle = SpanStyle(
+        baselineShift = BaselineShift(-0.2f),
+        // TODO this should be relative to current font size
+        fontSize = 10.sp
+      )
+
+      override fun getStyle(
+        richTextStyle: RichTextStringStyle,
+        contentColor: Color
+      ) = richTextStyle.subscriptStyle
+    }
+
+    object Superscript : Format("superscript") {
+      internal val DefaultStyle = SpanStyle(
+        baselineShift = BaselineShift.Superscript,
+        fontSize = 10.sp
+      )
+
+      override fun getStyle(
+        richTextStyle: RichTextStringStyle,
+        contentColor: Color
+      ) = richTextStyle.superscriptStyle
+    }
+
+    object Code : Format("code") {
+      internal val DefaultStyle = SpanStyle(
+        fontFamily = FontFamily.Monospace,
+        fontWeight = FontWeight.Medium,
+        background = DefaultCodeBlockBackground
+      )
+
+      override fun getStyle(
+        richTextStyle: RichTextStringStyle,
+        contentColor: Color
+      ) = richTextStyle.codeStyle
+    }
+
+    data class Link(val onClick: () -> Unit) : Format() {
+      override fun getStyle(
+        richTextStyle: RichTextStringStyle,
+        contentColor: Color
+      ) = richTextStyle.linkStyle!!.let { style ->
+        // Tweak the colors a bit to make it more likely to contrast with the background color.
+        val averagedValues = Color(
+          red = ((contentColor.red + style.color.red) * .5f
+              + style.color.red * .5f).coerceAtMost(1f),
+          green = ((contentColor.green + style.color.green) * .5f
+              + style.color.green * .5f).coerceAtMost(1f),
+          blue = ((contentColor.blue + style.color.blue) * .5f
+              + style.color.blue * .5f).coerceAtMost(1f)
+        )
+        style.copy(color = averagedValues)
+      }
+
+      internal companion object {
+        val DefaultStyle = SpanStyle(
+          textDecoration = TextDecoration.Underline,
+          color = Color.Blue
+        )
+      }
+    }
+
+    internal fun registerTag(tags: MutableMap<String, Any>): String {
+      simpleTag?.let { return it }
+      val uuid = UUID.randomUUID().toString()
+      tags[uuid] = this
+      return "format:$uuid"
+    }
+
+    internal companion object {
+      val FormatAnnotationScope = Format::class.java.name
+
+      // For some reason, if this isn't lazy, Bold will always be null. Is Compose messing up static
+      // initialization order?
+      private val simpleTags by lazy(NONE) {
+        listOf(Bold, Italic, Underline, Strikethrough, Subscript, Superscript, Code)
+      }
+
+      fun findTag(
+        tag: String,
+        tags: Map<String, Any>
+      ): Format? {
+        val stripped = tag.removePrefix("format:")
+        return if (stripped === tag) {
+          // If the original string was returned, it means the string did not have the prefix.
+          simpleTags.firstOrNull { it.simpleTag == tag }
+        } else {
+          tags[stripped] as? Format
+        }
+      }
+    }
+  }
+
+  class Builder(capacity: Int = 16) {
+    private val builder = AnnotatedString.Builder(capacity)
+    private val formatObjects = mutableMapOf<String, Any>()
+
+    fun addFormat(
+      format: Format,
+      start: Int,
+      end: Int
+    ) {
+      val tag = format.registerTag(formatObjects)
+      builder.addStringAnnotation(FormatAnnotationScope, tag, start, end)
+    }
+
+    fun pushFormat(format: Format): Int {
+      val tag = format.registerTag(formatObjects)
+      return builder.pushStringAnnotation(FormatAnnotationScope, tag)
+    }
+
+    fun pop() = builder.pop()
+
+    fun pop(index: Int) = builder.pop(index)
+
+    fun append(text: String) = builder.append(text)
+
+    fun append(text: RichTextString) {
+      builder.append(text.taggedString)
+      formatObjects.putAll(text.formatObjects)
+    }
+
+    fun appendInlineContent(alternateText: String = REPLACEMENT_CHAR, content: InlineContent) {
+      val tag = UUID.randomUUID().toString()
+      formatObjects["inline:$tag"] = content
+      builder.appendInlineContent(tag, alternateText)
+    }
+
+    /**
+     * Provides access to the underlying builder, which can be used to add arbitrary formatting,
+     * including mixed with formatting from this Builder.
+     */
+    fun <T> withAnnotatedString(block: AnnotatedString.Builder.() -> T): T = builder.block()
+
+    fun toRichTextString(): RichTextString =
+      RichTextString(
+        builder.toAnnotatedString(),
+        formatObjects.toMap()
+      )
+  }
+}
+
+inline fun Builder.withFormat(
+  format: Format,
+  block: Builder.() -> Unit
+) {
+  val index = pushFormat(format)
+  block()
+  pop(index)
+}

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/string/Text.kt
@@ -1,0 +1,296 @@
+package com.zachklipp.richtext.ui.string
+
+import androidx.animation.Infinite
+import androidx.animation.KeyframesBuilder
+import androidx.animation.LinearEasing
+import androidx.animation.RepeatableBuilder
+import androidx.animation.TweenBuilder
+import androidx.compose.Composable
+import androidx.compose.getValue
+import androidx.compose.launchInComposition
+import androidx.compose.onActive
+import androidx.compose.remember
+import androidx.compose.setValue
+import androidx.compose.state
+import androidx.compose.stateFor
+import androidx.ui.animation.animatedColor
+import androidx.ui.animation.animatedFloat
+import androidx.ui.core.Alignment
+import androidx.ui.core.Constraints
+import androidx.ui.core.ContextAmbient
+import androidx.ui.core.Layout
+import androidx.ui.core.Modifier
+import androidx.ui.core.Ref
+import androidx.ui.core.drawOpacity
+import androidx.ui.core.gesture.tapGestureFilter
+import androidx.ui.foundation.Canvas
+import androidx.ui.foundation.ContentColorAmbient
+import androidx.ui.foundation.Text
+import androidx.ui.foundation.clickable
+import androidx.ui.foundation.contentColor
+import androidx.ui.geometry.Offset
+import androidx.ui.graphics.Color
+import androidx.ui.graphics.StrokeCap
+import androidx.ui.graphics.drawscope.Stroke
+import androidx.ui.graphics.drawscope.withTransform
+import androidx.ui.layout.Stack
+import androidx.ui.layout.padding
+import androidx.ui.layout.size
+import androidx.ui.layout.wrapContentSize
+import androidx.ui.savedinstancestate.savedInstanceState
+import androidx.ui.text.TextLayoutResult
+import androidx.ui.text.TextStyle
+import androidx.ui.tooling.preview.Preview
+import androidx.ui.unit.dp
+import androidx.ui.unit.em
+import androidx.ui.unit.px
+import androidx.ui.unit.sp
+import com.zachklipp.richtext.ui.RichTextScope
+import com.zachklipp.richtext.ui.RichTextStyleAmbient
+import com.zachklipp.richtext.ui.string.RichTextString.Builder
+import com.zachklipp.richtext.ui.string.RichTextString.Format
+import com.zachklipp.richtext.ui.string.RichTextString.Format.Bold
+import com.zachklipp.richtext.ui.string.RichTextString.Format.Code
+import com.zachklipp.richtext.ui.string.RichTextString.Format.Italic
+import com.zachklipp.richtext.ui.string.RichTextString.Format.Link
+import com.zachklipp.richtext.ui.string.RichTextString.Format.Strikethrough
+import com.zachklipp.richtext.ui.string.RichTextString.Format.Subscript
+import com.zachklipp.richtext.ui.string.RichTextString.Format.Superscript
+import com.zachklipp.richtext.ui.string.RichTextString.Format.Underline
+import kotlinx.coroutines.delay
+import java.util.Locale
+
+private const val ZERO_WIDTH_CHAR = "\u200B"
+
+/**
+ * TODO kdoc
+ *
+ * @sample com.zachklipp.richtext.ui.string.TextPreview
+ */
+@Suppress("unused")
+@Composable
+fun RichTextScope.Text(
+  text: RichTextString,
+  modifier: Modifier = Modifier,
+  onTextLayout: (TextLayoutResult) -> Unit = {}
+) {
+  val style = RichTextStyleAmbient.current.stringStyle
+  val contentColor = ContentColorAmbient.current
+  val annotated = remember(text, style, contentColor) {
+    val resolvedStyle = (style ?: RichTextStringStyle.Default).resolveDefaults()
+    text.toAnnotatedString(resolvedStyle, contentColor)
+  }
+  val layoutResult = state<TextLayoutResult?> { null }
+  val pressIndicator = Modifier.tapGestureFilter { position ->
+    layoutResult.value?.let { layoutResult ->
+      val offset = layoutResult.getOffsetForPosition(position)
+      annotated.getStringAnnotations(Format.FormatAnnotationScope, offset, offset)
+        .asSequence()
+        .mapNotNull { Format.findTag(it.item, text.formatObjects) as? Link }
+        .firstOrNull()
+        ?.let { link -> link.onClick() }
+    }
+  }
+
+  val constraintsRef = remember { Ref<Constraints>() }
+  var hack by stateFor(annotated) { annotated }
+  val inlineContents = remember(text) { text.getInlineContents() }
+  // The constraints function won't be called until the content is actually composed and EM is
+  // measured, which won't happen until the text is composed.
+  val inlineTextContents = ManageInlineTextContents(
+    inlineContents = inlineContents,
+    textConstraints = { constraintsRef.value!! },
+    forceTextRelayout = {
+      // Modifying the actual string will cause Text to realize it needs to relayout.
+      // We use a special unicode character that doesn't render so there's no visual effect.
+      hack = hack.copy(text = hack.text + ZERO_WIDTH_CHAR)
+    }
+  )
+
+  // This is a giant hack to work around inline content limitations:
+  // 1. We have to ask content to measure themselves with our constraints so we can generate the
+  //    correct Placeholders.
+  // 2. Text doesn't re-layout the text when the placeholders change.
+  Layout(
+    modifier = modifier + pressIndicator,
+    children = {
+      Text(
+        text = hack,
+        onTextLayout = { result ->
+          layoutResult.value = result
+          onTextLayout(result)
+        },
+        inlineContent = inlineTextContents
+      )
+    }
+  ) { measurables, constraints, _ ->
+    // Update the inline content before measuring text, so content will get its constraints before
+    // being measured.
+    constraintsRef.value = constraints
+
+    val p = measurables.single().measure(constraints)
+    layout(p.width, p.height) {
+      p.place(0.px, 0.px)
+    }
+  }
+}
+
+@Preview(showBackground = true)
+@Composable internal fun TextPreview() {
+  val context = ContextAmbient.current
+  var toggleLink by state { false }
+  val text = remember(context, toggleLink) {
+    richTextString {
+      appendPreviewSentence(Bold)
+      appendPreviewSentence(Italic)
+      appendPreviewSentence(Underline)
+      appendPreviewSentence(Strikethrough)
+      appendPreviewSentence(Subscript)
+      appendPreviewSentence(Superscript)
+      appendPreviewSentence(Code)
+      appendPreviewSentence(
+        Link { toggleLink = !toggleLink },
+        if (toggleLink) "clicked link" else "link"
+      )
+      append("Here, ")
+      appendInlineContent(content = spinningCross)
+      append(", is an inline image. ")
+      append("And here, ")
+      appendInlineContent(content = slowLoadingImage)
+      append(", is an inline image that loads after some delay.")
+      append("\n\n")
+
+      append("Here ")
+      withFormat(Underline) {
+        append("is a ")
+        withFormat(Italic) {
+          append("longer sentence ")
+          withFormat(Bold) {
+            append("with many ")
+            withFormat(Code) {
+              append("different ")
+              withFormat(Strikethrough) {
+                append("nested")
+              }
+              append(" ")
+            }
+          }
+          append("styles.")
+        }
+      }
+    }
+  }
+  RichTextScope.Text(text)
+}
+
+private val spinningCross = InlineContent {
+  val angle = animatedFloat(0f)
+  val color = animatedColor(Color.Red)
+  onActive {
+    val angleAnim = RepeatableBuilder<Float>().apply {
+      iterations = Infinite
+      animation = TweenBuilder<Float>().apply {
+        duration = 1000
+        easing = LinearEasing
+      }
+    }
+    angle.animateTo(360f, angleAnim)
+
+    val colorAnim = RepeatableBuilder<Color>().apply {
+      iterations = Infinite
+      animation = KeyframesBuilder<Color>().apply {
+        duration = 2500
+        Color.Blue at 500
+        Color.Cyan at 1000
+        Color.Green at 1500
+        Color.Magenta at 2000
+      }
+    }
+    color.animateTo(Color.Yellow, colorAnim)
+  }
+
+  Canvas(modifier = Modifier.size(12.sp.toDp(), 12.sp.toDp()).padding(2.dp)) {
+    withTransform({ rotate(angle.value) }) {
+      val stroke = Stroke(width = 3.dp.toPx().value, cap = StrokeCap.round)
+      drawLine(
+        color.value,
+        Offset(0f, size.height / 2),
+        Offset(size.width, size.height / 2),
+        stroke
+      )
+      drawLine(
+        color.value,
+        Offset(size.width / 2, 0f),
+        Offset(size.width / 2, size.height),
+        stroke
+      )
+    }
+  }
+}
+
+val slowLoadingImage = InlineContent {
+  var loaded by savedInstanceState { false }
+  launchInComposition(loaded) {
+    if (!loaded) {
+      delay(3000)
+      loaded = true
+    }
+  }
+
+  if (!loaded) {
+    LoadingSpinner()
+  } else {
+    Stack(Modifier.clickable(onClick = { loaded = false })) {
+      val size = animatedFloat(16f)
+      onActive { size.animateTo(100f) }
+      Picture(Modifier.size(size.value.sp.toDp()))
+      Text(
+        "click to refresh",
+        modifier = Modifier.padding(3.dp).gravity(Alignment.Center),
+        fontSize = 8.sp,
+        style = TextStyle(background = Color.LightGray)
+      )
+    }
+  }
+}
+
+@Composable private fun LoadingSpinner() {
+  val alpha = animatedFloat(initVal = 1f)
+  onActive {
+    val anim = RepeatableBuilder<Float>().apply {
+      iterations = Infinite
+      animation = KeyframesBuilder<Float>().apply {
+        duration = 500
+        0f at 250
+        1f at 500
+      }
+    }
+    alpha.animateTo(0f, anim)
+  }
+  Text(
+    "⏳",
+    fontSize = 3.em,
+    modifier = Modifier.wrapContentSize(Alignment.Center)
+      .drawOpacity(alpha.value)
+  )
+}
+
+@Composable private fun Picture(modifier: Modifier) {
+  Canvas(modifier) {
+    drawRect(Color.LightGray)
+    drawLine(Color.Red, Offset(0f, 0f), Offset(size.width, size.height), Stroke())
+    drawLine(Color.Red, Offset(0f, size.height), Offset(size.width, 0f), Stroke())
+  }
+}
+
+@OptIn(ExperimentalStdlibApi::class)
+private fun Builder.appendPreviewSentence(
+  format: Format,
+  text: String = format.javaClass.simpleName.decapitalize(Locale.US)
+) {
+  append("Here is some ")
+  withFormat(format) {
+    append(text)
+  }
+  append(" text. ")
+}


### PR DESCRIPTION
This includes all the regular inline formatting you'd expect for
text, including bold/italic/underline, sub/superscript, etc. as
well as a more convenient API for adding clickable links and
inline composables than compose gives you out of the box.

The naming of many pieces is pretty awkward, but that will be
fixed later.

There are a few hacks going on here to allow inline composables to
automatically be sized using the normal measurement process instead
of specifying their size up-front like the `InlineTextContent` API
requires. This will almost certainly break at some point.

The API for creating text is an extension of Compose's `AnnotatedString`.
```kotlin
val text = remember {
  richTextString {
    append("This is plain text.\n")
    withFormat(Bold) { append("This text is bold.\n") }
    withFormat(Link { showTheAds() }) { append("Click here to WIN!\n") }

    val quoteIndex = pushFormat(Italic)
    append("Somebody once said… ")
    pushFormat(Subscript)
    append("…well actually I forgot, never mind.")
    pop(quoteIndex)

    withAnnotatedString {
      // Here you've got access to all the full AnnotatedString.Builder API, and
      // you can even interleave RichTextString.Builder calls.
      withStyle(SpanStyle(fontSize = 48.sp, fontWeight = ExtraBold)) {
        append("Thank you for coming to my TED talk.")
        val twitterUrl = "twitter.com/me"
        appendInlineContent(alternateText = twitterUrl) {
          // This is a regular Image composable – any composables can go here,
          // even legacy Android views!
          Image(twitterLogo, Modifier.clickable { openUrl(twitterUrl) })
        }
      }
    }
  }
}
```
The actual mapping of high-level tags like "bold" and "italic" to actual text styles is done via the `RichTextStyle` at the root of the `RichText` composable, just like everything else.

To display `RichTextString`s, there's a `Text` composable that is similar to the built-in ones, but it's scoped to `RichTextScope` like all the other composables in this library:
```kotlin
  RichText {
    BlockQuote {
      Text(text)
    }
  }
```

Like pretty much everything in Compose, animating everything is pretty easy.

![ezgif com-optimize](https://user-images.githubusercontent.com/101754/84614356-b68a9500-ae7a-11ea-9726-a6e13f659025.gif)

Fixes #1 and fixes #2.
