### PR TITLE
Fix docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,9 @@
 name: Doc Site
 
 on:
-  repository_dispatch:
+  release:
     # Only build docs when a new release is created, so the API docs don't get out of date.
-    types: [ release ]
+    types: [ published ]
   push:
     branches:
       # Build the branch that introduced this config, for testing.


### PR DESCRIPTION
Was using the wrong syntax to publish a release. Re-using the `zachklipp/mkdocs` branch to force a deploy with this PR, since I just published a release.