### PR TITLE
Remove Redundant dependencies in richtext-commonmark/build.gradle 

### DIFF
--- a/richtext-commonmark/build.gradle
+++ b/richtext-commonmark/build.gradle
@@ -8,8 +8,6 @@ dependencies {
   compileOnly deps.compose.tooling
 
   api project(":richtext-ui")
-  api deps.compose.foundation
-  api deps.compose.text
 
   implementation deps.accompanist
   implementation deps.commonmark.core


### PR DESCRIPTION
`compose.foundation` & `compose.text` dependencies are already exposed by `:richtext-ui` module, So no need to depend on them individually