### PR TITLE
Split richtext-ui into BasicRichText and richtext-ui-material

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,9 @@
 buildscript {
   ext.versions = [
       targetSdk: 29,
-      compose: '1.0.0-beta01',
-      kotlin: '1.4.30',
-      commonmark: '0.15.2'
+      compose: '1.0.0-beta03',
+      kotlin: '1.4.31',
+      commonmark: '0.17.1'
   ]
 
   rootProject.ext.defaultAndroidConfig = {
@@ -32,7 +32,7 @@ buildscript {
   }
 
   ext.deps = [
-      android_gradle_plugin: "com.android.tools.build:gradle:7.0.0-alpha08",
+      android_gradle_plugin: "com.android.tools.build:gradle:7.0.0-alpha12",
 
       androidx: [
           activity: "androidx.activity:activity:1.1.0",
@@ -51,7 +51,7 @@ buildscript {
           viewbinding: "androidx.databinding:viewbinding:3.6.1",
       ],
       compose: [
-          activity: "androidx.activity:activity-compose:1.3.0-alpha03",
+          activity: "androidx.activity:activity-compose:1.3.0-alpha05",
           foundation: "androidx.compose.foundation:foundation:${versions.compose}",
           layout: "androidx.compose.foundation:foundation-layout:${versions.compose}",
           material: "androidx.compose.material:material:${versions.compose}",
@@ -73,11 +73,11 @@ buildscript {
           ]
       ],
       commonmark: [
-          core: "com.atlassian.commonmark:commonmark:${versions.commonmark}",
-          tables: "com.atlassian.commonmark:commonmark-ext-gfm-tables:${versions.commonmark}",
-          strikethrough: "com.atlassian.commonmark:commonmark-ext-gfm-strikethrough:${versions.commonmark}"
+          core: "org.commonmark:commonmark:${versions.commonmark}",
+          tables: "org.commonmark:commonmark-ext-gfm-tables:${versions.commonmark}",
+          strikethrough: "org.commonmark:commonmark-ext-gfm-strikethrough:${versions.commonmark}"
       ],
-      accompanist: "dev.chrisbanes.accompanist:accompanist-coil:0.6.1",
+      accompanist: "com.google.accompanist:accompanist-coil:0.7.0",
       mavenPublish: "com.vanniktech:gradle-maven-publish-plugin:0.13.0",
       ktlint: "org.jlleitschuh.gradle:ktlint-gradle:9.2.0",
   ]

--- a/docs/richtext-commonmark.md
+++ b/docs/richtext-commonmark.md
@@ -1,6 +1,6 @@
 # Markdown
 
-Library for rendering Markdown in Compose using Atlassian's [CommonMark](https://github.com/atlassian/commonmark-java)
+Library for rendering Markdown in Compose using [CommonMark](https://github.com/commonmark/commonmark-java)
 library to parse, and `richtext-ui` to render.
 
 ## Gradle

--- a/richtext-commonmark/api/richtext-commonmark.api
+++ b/richtext-commonmark/api/richtext-commonmark.api
@@ -1,8 +1,49 @@
+public final class com/zachklipp/richtext/markdown/AndroidHtmlBlock : com/zachklipp/richtext/markdown/HtmlBlock {
+	public fun <init> ()V
+	public fun <init> (Landroidx/compose/ui/Modifier;)V
+	public synthetic fun <init> (Landroidx/compose/ui/Modifier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Landroidx/compose/ui/Modifier;
+	public final fun copy (Landroidx/compose/ui/Modifier;)Lcom/zachklipp/richtext/markdown/AndroidHtmlBlock;
+	public static synthetic fun copy$default (Lcom/zachklipp/richtext/markdown/AndroidHtmlBlock;Landroidx/compose/ui/Modifier;ILjava/lang/Object;)Lcom/zachklipp/richtext/markdown/AndroidHtmlBlock;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getModifier ()Landroidx/compose/ui/Modifier;
+	public fun hashCode ()I
+	public fun onDraw (Ljava/lang/String;Landroidx/compose/runtime/Composer;I)V
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/zachklipp/richtext/markdown/BuildConfig {
 	public static final field BUILD_TYPE Ljava/lang/String;
 	public static final field DEBUG Z
 	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
 	public fun <init> ()V
+}
+
+public final class com/zachklipp/richtext/markdown/CoilInlineImage : com/zachklipp/richtext/markdown/InlineImage {
+	public fun <init> ()V
+	public fun <init> (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Landroidx/compose/ui/Modifier;
+	public final fun component2 ()Lkotlin/jvm/functions/Function2;
+	public final fun component3 ()Lkotlin/jvm/functions/Function2;
+	public final fun copy (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Lcom/zachklipp/richtext/markdown/CoilInlineImage;
+	public static synthetic fun copy$default (Lcom/zachklipp/richtext/markdown/CoilInlineImage;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lcom/zachklipp/richtext/markdown/CoilInlineImage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getError ()Lkotlin/jvm/functions/Function2;
+	public final fun getLoading ()Lkotlin/jvm/functions/Function2;
+	public final fun getModifier ()Landroidx/compose/ui/Modifier;
+	public fun hashCode ()I
+	public fun onDraw (Ljava/lang/String;Ljava/lang/String;Landroidx/compose/runtime/Composer;I)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/zachklipp/richtext/markdown/ComposableSingletons$InlineImageKt {
+	public static final field INSTANCE Lcom/zachklipp/richtext/markdown/ComposableSingletons$InlineImageKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public static field lambda-2 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$richtext_commonmark_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-2$richtext_commonmark_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/zachklipp/richtext/markdown/ComposableSingletons$MarkdownKt {
@@ -14,16 +55,40 @@ public final class com/zachklipp/richtext/markdown/ComposableSingletons$Markdown
 	public final fun getLambda-2$richtext_commonmark_release ()Lkotlin/jvm/functions/Function4;
 }
 
-public final class com/zachklipp/richtext/markdown/ComposableSingletons$MarkdownRichTextKt {
-	public static final field INSTANCE Lcom/zachklipp/richtext/markdown/ComposableSingletons$MarkdownRichTextKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function4;
-	public static field lambda-2 Lkotlin/jvm/functions/Function3;
+public abstract interface class com/zachklipp/richtext/markdown/HtmlBlock {
+	public abstract fun onDraw (Ljava/lang/String;Landroidx/compose/runtime/Composer;I)V
+}
+
+public abstract interface class com/zachklipp/richtext/markdown/InlineImage {
+	public abstract fun onDraw (Ljava/lang/String;Ljava/lang/String;Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class com/zachklipp/richtext/markdown/MarkdownConfiguration {
+	public static final field Companion Lcom/zachklipp/richtext/markdown/MarkdownConfiguration$Companion;
 	public fun <init> ()V
-	public final fun getLambda-1$richtext_commonmark_release ()Lkotlin/jvm/functions/Function4;
-	public final fun getLambda-2$richtext_commonmark_release ()Lkotlin/jvm/functions/Function3;
+	public fun <init> (Lcom/zachklipp/richtext/markdown/InlineImage;Lcom/zachklipp/richtext/markdown/HtmlBlock;)V
+	public synthetic fun <init> (Lcom/zachklipp/richtext/markdown/InlineImage;Lcom/zachklipp/richtext/markdown/HtmlBlock;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/zachklipp/richtext/markdown/InlineImage;
+	public final fun component2 ()Lcom/zachklipp/richtext/markdown/HtmlBlock;
+	public final fun copy (Lcom/zachklipp/richtext/markdown/InlineImage;Lcom/zachklipp/richtext/markdown/HtmlBlock;)Lcom/zachklipp/richtext/markdown/MarkdownConfiguration;
+	public static synthetic fun copy$default (Lcom/zachklipp/richtext/markdown/MarkdownConfiguration;Lcom/zachklipp/richtext/markdown/InlineImage;Lcom/zachklipp/richtext/markdown/HtmlBlock;ILjava/lang/Object;)Lcom/zachklipp/richtext/markdown/MarkdownConfiguration;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHtmlBlock ()Lcom/zachklipp/richtext/markdown/HtmlBlock;
+	public final fun getInlineImage ()Lcom/zachklipp/richtext/markdown/InlineImage;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/zachklipp/richtext/markdown/MarkdownConfiguration$Companion {
+	public final fun getDefault ()Lcom/zachklipp/richtext/markdown/MarkdownConfiguration;
+}
+
+public final class com/zachklipp/richtext/markdown/MarkdownConfigurationKt {
+	public static final fun merge (Lcom/zachklipp/richtext/markdown/MarkdownConfiguration;Lcom/zachklipp/richtext/markdown/MarkdownConfiguration;)Lcom/zachklipp/richtext/markdown/MarkdownConfiguration;
+	public static final fun resolveDefaults (Lcom/zachklipp/richtext/markdown/MarkdownConfiguration;)Lcom/zachklipp/richtext/markdown/MarkdownConfiguration;
 }
 
 public final class com/zachklipp/richtext/markdown/MarkdownKt {
-	public static final fun Markdown (Ljava/lang/String;Landroidx/compose/ui/Modifier;Lcom/zachklipp/richtext/ui/RichTextStyle;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun Markdown (Lcom/zachklipp/richtext/ui/RichTextScope;Ljava/lang/String;Lcom/zachklipp/richtext/markdown/MarkdownConfiguration;Landroidx/compose/runtime/Composer;II)V
 }
 

--- a/richtext-commonmark/build.gradle
+++ b/richtext-commonmark/build.gradle
@@ -13,7 +13,4 @@ dependencies {
   implementation deps.commonmark.core
   implementation deps.commonmark.strikethrough
   implementation deps.commonmark.tables
-
-  // TODO Migrate off this.
-  implementation deps.compose.material
 }

--- a/richtext-commonmark/src/main/java/com/zachklipp/richtext/markdown/HtmlBlock.kt
+++ b/richtext-commonmark/src/main/java/com/zachklipp/richtext/markdown/HtmlBlock.kt
@@ -1,0 +1,36 @@
+package com.zachklipp.richtext.markdown
+
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
+import android.text.Html
+import android.widget.TextView
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+
+public interface HtmlBlock {
+  @Composable public fun onDraw(html: String)
+}
+
+@Immutable
+public data class AndroidHtmlBlock(
+  val modifier: Modifier = Modifier
+) : HtmlBlock {
+  @Composable override fun onDraw(html: String) {
+    AndroidView(
+      factory = { context ->
+        // TODO: pass current styling to legacy TextView
+        TextView(context).apply {
+          text = if (VERSION.SDK_INT >= VERSION_CODES.N) {
+            Html.fromHtml(html, 0)
+          } else {
+            @Suppress("DEPRECATION")
+            Html.fromHtml(html)
+          }
+        }
+      },
+      modifier = modifier
+    )
+  }
+}

--- a/richtext-commonmark/src/main/java/com/zachklipp/richtext/markdown/InlineImage.kt
+++ b/richtext-commonmark/src/main/java/com/zachklipp/richtext/markdown/InlineImage.kt
@@ -1,0 +1,28 @@
+package com.zachklipp.richtext.markdown
+
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.Modifier
+import com.google.accompanist.coil.CoilImage
+
+public interface InlineImage {
+  @Composable public fun onDraw(text: String, destination: String)
+}
+
+@Immutable
+public data class CoilInlineImage(
+  val modifier: Modifier = Modifier,
+  val loading: @Composable () -> Unit = { BasicText("Loading Image...") },
+  val error: @Composable () -> Unit = { BasicText("Image failed to load") }
+) : InlineImage {
+  @Composable override fun onDraw(text: String, destination: String) {
+    CoilImage(
+      data = destination,
+      contentDescription = text,
+      modifier = modifier,
+      loading = { loading() },
+      error = { error() }
+    )
+  }
+}

--- a/richtext-commonmark/src/main/java/com/zachklipp/richtext/markdown/MarkdownConfiguration.kt
+++ b/richtext-commonmark/src/main/java/com/zachklipp/richtext/markdown/MarkdownConfiguration.kt
@@ -1,0 +1,26 @@
+package com.zachklipp.richtext.markdown
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.compositionLocalOf
+
+internal val LocalMarkdownConfiguration = compositionLocalOf { MarkdownConfiguration.Default }
+
+@Immutable
+public data class MarkdownConfiguration(
+  val inlineImage: InlineImage? = null,
+  val htmlBlock: HtmlBlock? = null
+) {
+  public companion object {
+    public val Default: MarkdownConfiguration = MarkdownConfiguration()
+  }
+}
+
+public fun MarkdownConfiguration.merge(other: MarkdownConfiguration?): MarkdownConfiguration = MarkdownConfiguration(
+  inlineImage = other?.inlineImage ?: inlineImage,
+  htmlBlock = other?.htmlBlock ?: htmlBlock
+)
+
+public fun MarkdownConfiguration.resolveDefaults(): MarkdownConfiguration = MarkdownConfiguration(
+  inlineImage = inlineImage ?: CoilInlineImage(),
+  htmlBlock = htmlBlock ?: AndroidHtmlBlock()
+)

--- a/richtext-commonmark/src/main/java/com/zachklipp/richtext/markdown/MarkdownTable.kt
+++ b/richtext-commonmark/src/main/java/com/zachklipp/richtext/markdown/MarkdownTable.kt
@@ -10,7 +10,7 @@ import com.zachklipp.richtext.ui.RichTextScope
 import com.zachklipp.richtext.ui.Table
 
 @Composable
-internal fun RichTextScope.renderTable(node: AstTableRoot) {
+internal fun RichTextScope.MarkdownTable(node: AstTableRoot) {
   Table(
     headerRow = {
       node.filterChildrenIsInstance<AstTableHeader>()

--- a/richtext-ui-material/api/richtext-ui-material.api
+++ b/richtext-ui-material/api/richtext-ui-material.api
@@ -1,0 +1,11 @@
+public final class com/zachklipp/richtext/ui/material/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public final class com/zachklipp/richtext/ui/material/MaterialAdapterKt {
+	public static final fun RichText-fWhpE4E (Landroidx/compose/ui/Modifier;Lcom/zachklipp/richtext/ui/RichTextStyle;Landroidx/compose/ui/text/TextStyle;JLandroidx/compose/ui/Alignment$Horizontal;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+}
+

--- a/richtext-ui-material/build.gradle
+++ b/richtext-ui-material/build.gradle
@@ -5,8 +5,13 @@ apply from: rootProject.file('gradle/maven-publish.gradle')
 android rootProject.ext.defaultAndroidConfig
 
 dependencies {
-  compileOnly deps.compose.tooling
-
-  api deps.androidx.annotations
+  api project(":richtext-ui")
   api deps.compose.foundation
+  api deps.compose.material
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+  kotlinOptions {
+    freeCompilerArgs += ["-Xinline-classes"]
+  }
 }

--- a/richtext-ui-material/gradle.properties
+++ b/richtext-ui-material/gradle.properties
@@ -1,0 +1,4 @@
+POM_ARTIFACT_ID=richtext-ui-material
+POM_NAME=Compose Richtext UI
+POM_DESCRIPTION=A library for providing Richtext UI with Material Theming.
+POM_PACKAGING=aar

--- a/richtext-ui-material/proguard-rules.pro
+++ b/richtext-ui-material/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/richtext-ui-material/src/main/AndroidManifest.xml
+++ b/richtext-ui-material/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.zachklipp.richtext.ui.material" />

--- a/richtext-ui-material/src/main/java/com/zachklipp/richtext/ui/material/MaterialAdapter.kt
+++ b/richtext-ui-material/src/main/java/com/zachklipp/richtext/ui/material/MaterialAdapter.kt
@@ -1,0 +1,40 @@
+package com.zachklipp.richtext.ui.material
+
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.LocalTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.text.TextStyle
+import com.zachklipp.richtext.ui.BasicRichText
+import com.zachklipp.richtext.ui.RichTextScope
+import com.zachklipp.richtext.ui.RichTextStyle
+
+@Composable
+public fun RichText(
+  modifier: Modifier = Modifier,
+  richTextStyle: RichTextStyle? = null,
+  textStyle: TextStyle? = null,
+  color: Color = Color.Unspecified,
+  alignment: Alignment.Horizontal = Alignment.Start,
+  children: @Composable RichTextScope.() -> Unit
+) {
+  val fallbackContentColor = LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
+  val resolvedContentColor = color.takeOrElse {
+    textStyle?.color?.takeOrElse { fallbackContentColor } ?: fallbackContentColor
+  }
+
+  val resolvedTextStyle = textStyle ?: LocalTextStyle.current
+
+  BasicRichText(
+    modifier = modifier,
+    richTextStyle = richTextStyle,
+    textStyle = resolvedTextStyle,
+    contentColor = resolvedContentColor,
+    alignment = alignment,
+    children = children
+  )
+}

--- a/richtext-ui/api/richtext-ui.api
+++ b/richtext-ui/api/richtext-ui.api
@@ -1,3 +1,7 @@
+public final class com/zachklipp/richtext/ui/BasicRichTextKt {
+	public static final fun BasicRichText-_trzp-w (Landroidx/compose/ui/Modifier;Lcom/zachklipp/richtext/ui/RichTextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/Alignment$Horizontal;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+}
+
 public abstract interface class com/zachklipp/richtext/ui/BlockQuoteGutter {
 	public abstract fun drawGutter (Landroidx/compose/runtime/Composer;I)V
 }
@@ -107,6 +111,23 @@ public final class com/zachklipp/richtext/ui/HorizontalRuleKt {
 	public static final fun HorizontalRule (Lcom/zachklipp/richtext/ui/RichTextScope;Landroidx/compose/runtime/Composer;I)V
 }
 
+public final class com/zachklipp/richtext/ui/HorizontalRuleStyle {
+	public static final field Companion Lcom/zachklipp/richtext/ui/HorizontalRuleStyle$Companion;
+	public synthetic fun <init> (Landroidx/compose/ui/graphics/Color;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Landroidx/compose/ui/graphics/Color;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-QN2ZGVo ()Landroidx/compose/ui/graphics/Color;
+	public final fun copy-Y2TPw74 (Landroidx/compose/ui/graphics/Color;)Lcom/zachklipp/richtext/ui/HorizontalRuleStyle;
+	public static synthetic fun copy-Y2TPw74$default (Lcom/zachklipp/richtext/ui/HorizontalRuleStyle;Landroidx/compose/ui/graphics/Color;ILjava/lang/Object;)Lcom/zachklipp/richtext/ui/HorizontalRuleStyle;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getColor-QN2ZGVo ()Landroidx/compose/ui/graphics/Color;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/zachklipp/richtext/ui/HorizontalRuleStyle$Companion {
+	public final fun getDefault ()Lcom/zachklipp/richtext/ui/HorizontalRuleStyle;
+}
+
 public final class com/zachklipp/richtext/ui/ListStyle {
 	public static final field Companion Lcom/zachklipp/richtext/ui/ListStyle$Companion;
 	public synthetic fun <init> (Landroidx/compose/ui/unit/TextUnit;Landroidx/compose/ui/unit/TextUnit;Lcom/zachklipp/richtext/ui/OrderedMarkers;Lcom/zachklipp/richtext/ui/UnorderedMarkers;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -139,16 +160,12 @@ public final class com/zachklipp/richtext/ui/ListType : java/lang/Enum {
 
 public abstract interface class com/zachklipp/richtext/ui/OrderedMarkers {
 	public static final field Companion Lcom/zachklipp/richtext/ui/OrderedMarkers$Companion;
-	public abstract fun drawMarker (IILandroidx/compose/runtime/Composer;I)V
+	public abstract fun drawMarker (Lcom/zachklipp/richtext/ui/RichTextScope;IILandroidx/compose/runtime/Composer;I)V
 }
 
 public final class com/zachklipp/richtext/ui/OrderedMarkers$Companion {
-	public final fun invoke (Lkotlin/jvm/functions/Function4;)Lcom/zachklipp/richtext/ui/OrderedMarkers;
+	public final fun invoke (Lkotlin/jvm/functions/Function5;)Lcom/zachklipp/richtext/ui/OrderedMarkers;
 	public final fun text ([Lkotlin/jvm/functions/Function1;)Lcom/zachklipp/richtext/ui/OrderedMarkers;
-}
-
-public final class com/zachklipp/richtext/ui/RichTextKt {
-	public static final fun RichText (Landroidx/compose/ui/Modifier;Lcom/zachklipp/richtext/ui/RichTextStyle;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/zachklipp/richtext/ui/RichTextScope {
@@ -157,13 +174,14 @@ public final class com/zachklipp/richtext/ui/RichTextScope {
 
 public final class com/zachklipp/richtext/ui/RichTextScopeKt {
 	public static final fun WithStyle (Lcom/zachklipp/richtext/ui/RichTextScope;Lcom/zachklipp/richtext/ui/RichTextStyle;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)V
+	public static final fun getCurrentBasicTextStyle (Lcom/zachklipp/richtext/ui/RichTextScope;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/text/TextStyle;
 	public static final fun getCurrentRichTextStyle (Lcom/zachklipp/richtext/ui/RichTextScope;Landroidx/compose/runtime/Composer;I)Lcom/zachklipp/richtext/ui/RichTextStyle;
 }
 
 public final class com/zachklipp/richtext/ui/RichTextStyle {
 	public static final field Companion Lcom/zachklipp/richtext/ui/RichTextStyle$Companion;
-	public synthetic fun <init> (Landroidx/compose/ui/unit/TextUnit;Lkotlin/jvm/functions/Function2;Lcom/zachklipp/richtext/ui/ListStyle;Lcom/zachklipp/richtext/ui/BlockQuoteGutter;Lcom/zachklipp/richtext/ui/CodeBlockStyle;Lcom/zachklipp/richtext/ui/TableStyle;Lcom/zachklipp/richtext/ui/string/RichTextStringStyle;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Landroidx/compose/ui/unit/TextUnit;Lkotlin/jvm/functions/Function2;Lcom/zachklipp/richtext/ui/ListStyle;Lcom/zachklipp/richtext/ui/BlockQuoteGutter;Lcom/zachklipp/richtext/ui/CodeBlockStyle;Lcom/zachklipp/richtext/ui/TableStyle;Lcom/zachklipp/richtext/ui/string/RichTextStringStyle;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Landroidx/compose/ui/unit/TextUnit;Lkotlin/jvm/functions/Function2;Lcom/zachklipp/richtext/ui/ListStyle;Lcom/zachklipp/richtext/ui/BlockQuoteGutter;Lcom/zachklipp/richtext/ui/CodeBlockStyle;Lcom/zachklipp/richtext/ui/TableStyle;Lcom/zachklipp/richtext/ui/string/RichTextStringStyle;Lcom/zachklipp/richtext/ui/HorizontalRuleStyle;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Landroidx/compose/ui/unit/TextUnit;Lkotlin/jvm/functions/Function2;Lcom/zachklipp/richtext/ui/ListStyle;Lcom/zachklipp/richtext/ui/BlockQuoteGutter;Lcom/zachklipp/richtext/ui/CodeBlockStyle;Lcom/zachklipp/richtext/ui/TableStyle;Lcom/zachklipp/richtext/ui/string/RichTextStringStyle;Lcom/zachklipp/richtext/ui/HorizontalRuleStyle;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-U3a4LBI ()Landroidx/compose/ui/unit/TextUnit;
 	public final fun component2 ()Lkotlin/jvm/functions/Function2;
 	public final fun component3 ()Lcom/zachklipp/richtext/ui/ListStyle;
@@ -171,12 +189,14 @@ public final class com/zachklipp/richtext/ui/RichTextStyle {
 	public final fun component5 ()Lcom/zachklipp/richtext/ui/CodeBlockStyle;
 	public final fun component6 ()Lcom/zachklipp/richtext/ui/TableStyle;
 	public final fun component7 ()Lcom/zachklipp/richtext/ui/string/RichTextStringStyle;
-	public final fun copy-rSDT1DU (Landroidx/compose/ui/unit/TextUnit;Lkotlin/jvm/functions/Function2;Lcom/zachklipp/richtext/ui/ListStyle;Lcom/zachklipp/richtext/ui/BlockQuoteGutter;Lcom/zachklipp/richtext/ui/CodeBlockStyle;Lcom/zachklipp/richtext/ui/TableStyle;Lcom/zachklipp/richtext/ui/string/RichTextStringStyle;)Lcom/zachklipp/richtext/ui/RichTextStyle;
-	public static synthetic fun copy-rSDT1DU$default (Lcom/zachklipp/richtext/ui/RichTextStyle;Landroidx/compose/ui/unit/TextUnit;Lkotlin/jvm/functions/Function2;Lcom/zachklipp/richtext/ui/ListStyle;Lcom/zachklipp/richtext/ui/BlockQuoteGutter;Lcom/zachklipp/richtext/ui/CodeBlockStyle;Lcom/zachklipp/richtext/ui/TableStyle;Lcom/zachklipp/richtext/ui/string/RichTextStringStyle;ILjava/lang/Object;)Lcom/zachklipp/richtext/ui/RichTextStyle;
+	public final fun component8 ()Lcom/zachklipp/richtext/ui/HorizontalRuleStyle;
+	public final fun copy-HWmCdDM (Landroidx/compose/ui/unit/TextUnit;Lkotlin/jvm/functions/Function2;Lcom/zachklipp/richtext/ui/ListStyle;Lcom/zachklipp/richtext/ui/BlockQuoteGutter;Lcom/zachklipp/richtext/ui/CodeBlockStyle;Lcom/zachklipp/richtext/ui/TableStyle;Lcom/zachklipp/richtext/ui/string/RichTextStringStyle;Lcom/zachklipp/richtext/ui/HorizontalRuleStyle;)Lcom/zachklipp/richtext/ui/RichTextStyle;
+	public static synthetic fun copy-HWmCdDM$default (Lcom/zachklipp/richtext/ui/RichTextStyle;Landroidx/compose/ui/unit/TextUnit;Lkotlin/jvm/functions/Function2;Lcom/zachklipp/richtext/ui/ListStyle;Lcom/zachklipp/richtext/ui/BlockQuoteGutter;Lcom/zachklipp/richtext/ui/CodeBlockStyle;Lcom/zachklipp/richtext/ui/TableStyle;Lcom/zachklipp/richtext/ui/string/RichTextStringStyle;Lcom/zachklipp/richtext/ui/HorizontalRuleStyle;ILjava/lang/Object;)Lcom/zachklipp/richtext/ui/RichTextStyle;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBlockQuoteGutter ()Lcom/zachklipp/richtext/ui/BlockQuoteGutter;
 	public final fun getCodeBlockStyle ()Lcom/zachklipp/richtext/ui/CodeBlockStyle;
 	public final fun getHeadingStyle ()Lkotlin/jvm/functions/Function2;
+	public final fun getHorizontalRuleStyle ()Lcom/zachklipp/richtext/ui/HorizontalRuleStyle;
 	public final fun getListStyle ()Lcom/zachklipp/richtext/ui/ListStyle;
 	public final fun getParagraphSpacing-U3a4LBI ()Landroidx/compose/ui/unit/TextUnit;
 	public final fun getStringStyle ()Lcom/zachklipp/richtext/ui/string/RichTextStringStyle;
@@ -231,11 +251,11 @@ public final class com/zachklipp/richtext/ui/TableStyle$Companion {
 
 public abstract interface class com/zachklipp/richtext/ui/UnorderedMarkers {
 	public static final field Companion Lcom/zachklipp/richtext/ui/UnorderedMarkers$Companion;
-	public abstract fun drawMarker (ILandroidx/compose/runtime/Composer;I)V
+	public abstract fun drawMarker (Lcom/zachklipp/richtext/ui/RichTextScope;ILandroidx/compose/runtime/Composer;I)V
 }
 
 public final class com/zachklipp/richtext/ui/UnorderedMarkers$Companion {
-	public final fun invoke (Lkotlin/jvm/functions/Function3;)Lcom/zachklipp/richtext/ui/UnorderedMarkers;
+	public final fun invoke (Lkotlin/jvm/functions/Function4;)Lcom/zachklipp/richtext/ui/UnorderedMarkers;
 	public final fun painters ([Landroidx/compose/ui/graphics/painter/Painter;)Lcom/zachklipp/richtext/ui/UnorderedMarkers;
 	public final fun text ([Ljava/lang/String;)Lcom/zachklipp/richtext/ui/UnorderedMarkers;
 }

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/BasicRichText.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/BasicRichText.kt
@@ -5,29 +5,45 @@ package com.zachklipp.richtext.ui
 import androidx.compose.foundation.layout.Arrangement.spacedBy
 import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextStyle
 
 /**
  * Draws some rich text. Entry point to the compose-richtext library.
  */
 @Composable
-public fun RichText(
+public fun BasicRichText(
   modifier: Modifier = Modifier,
-  style: RichTextStyle? = null,
+  richTextStyle: RichTextStyle? = null,
+  textStyle: TextStyle? = null,
+  contentColor: Color? = null,
+  alignment: Alignment.Horizontal = Alignment.Start,
   children: @Composable RichTextScope.() -> Unit
 ) {
   with(RichTextScope) {
     // Nested RichTexts should not continue list leveling from the parent.
     RestartListLevel {
-      WithStyle(style) {
+      WithStyle(richTextStyle) {
         val resolvedStyle = currentRichTextStyle.resolveDefaults()
         val blockSpacing = with(LocalDensity.current) {
           resolvedStyle.paragraphSpacing!!.toDp()
         }
 
-        Column(modifier = modifier, verticalArrangement = spacedBy(blockSpacing)) {
-          children()
+        ProvideBasicTextStyle(textStyle) {
+          val currentContentColor = LocalContentColor.current
+          CompositionLocalProvider(LocalContentColor provides (contentColor ?: currentContentColor)) {
+            Column(
+              modifier = modifier,
+              verticalArrangement = spacedBy(blockSpacing),
+              horizontalAlignment = alignment
+            ) {
+              children()
+            }
+          }
         }
       }
     }

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/BlockQuote.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/BlockQuote.kt
@@ -7,8 +7,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.LocalContentColor
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
@@ -73,7 +71,7 @@ public interface BlockQuoteGutter {
 
   Layout(content = {
     gutter.drawGutter()
-    RichText(
+    BasicRichText(
       modifier = Modifier.padding(top = spacing, bottom = spacing),
       children = children
     )
@@ -110,24 +108,24 @@ public interface BlockQuoteGutter {
 }
 
 @Preview @Composable private fun BlockQuotePreviewOnWhite() {
-  BlockQuotePreview(backgroundColor = Color.White, contentColor = Color.Black)
+  BlockQuotePreview(backgroundColor = Color.White, textColor = Color.Black)
 }
 
 @Preview @Composable private fun BlockQuotePreviewOnBlack() {
-  BlockQuotePreview(backgroundColor = Color.Black, contentColor = Color.White)
+  BlockQuotePreview(backgroundColor = Color.Black, textColor = Color.White)
 }
 
 @Composable private fun BlockQuotePreview(
   backgroundColor: Color,
-  contentColor: Color
+  textColor: Color
 ) {
-  CompositionLocalProvider(LocalContentColor provides contentColor) {
+  CompositionLocalProvider(LocalContentColor provides textColor) {
     Box(Modifier.background(backgroundColor)) {
       RichTextScope.BlockQuote {
-        Text("Some text.")
-        Text("Another paragraph.")
+        BasicText("Some text.")
+        BasicText("Another paragraph.")
         BlockQuote {
-          Text("Nested block quote.")
+          BasicText("Nested block quote.")
         }
       }
     }

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/CodeBlock.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/CodeBlock.kt
@@ -5,11 +5,6 @@ package com.zachklipp.richtext.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.BasicText
-import androidx.compose.material.LocalContentColor
-import androidx.compose.material.LocalTextStyle
-import androidx.compose.material.ProvideTextStyle
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
@@ -60,7 +55,7 @@ internal fun CodeBlockStyle.resolveDefaults() = CodeBlockStyle(
  */
 @Composable public fun RichTextScope.CodeBlock(text: String) {
   CodeBlock {
-    Text(text)
+    BasicText(text)
   }
 }
 
@@ -68,18 +63,20 @@ internal fun CodeBlockStyle.resolveDefaults() = CodeBlockStyle(
  * A specially-formatted block of text that typically uses a monospace font with a tinted
  * background.
  */
-@Composable public fun RichTextScope.CodeBlock(children: @Composable RichTextScope.() -> Unit) {
-  val richTextStyle = currentRichTextStyle.resolveDefaults().codeBlockStyle!!
-  val textStyle = LocalTextStyle.current.merge(richTextStyle.textStyle)
-  val background = Modifier.background(color = richTextStyle.background!!)
+@Composable public fun RichTextScope.CodeBlock(
+  children: @Composable RichTextScope.() -> Unit
+) {
+  val codeBlockStyle = currentRichTextStyle.resolveDefaults().codeBlockStyle!!
+  val textStyleForCodeBlock = currentBasicTextStyle.merge(codeBlockStyle.textStyle)
+
   val blockPadding = with(LocalDensity.current) {
-    richTextStyle.padding!!.toDp()
+    codeBlockStyle.padding!!.toDp()
   }
 
-  Box(modifier = background) {
-    // Can't use Box(padding=) because that property doesn't seem affect the intrinsic size.
-    Box(Modifier.padding(blockPadding)) {
-      ProvideTextStyle(textStyle) {
+  ProvideBasicTextStyle(textStyleForCodeBlock) {
+    Box(modifier = Modifier.background(color = codeBlockStyle.background!!)) {
+      // Can't use Box(padding=) because that property doesn't seem affect the intrinsic size.
+      Box(modifier = Modifier.padding(blockPadding)) {
         children()
       }
     }
@@ -88,20 +85,20 @@ internal fun CodeBlockStyle.resolveDefaults() = CodeBlockStyle(
 
 @Preview @Composable
 private fun CodeBlockPreviewOnWhite() {
-  CodeBlockPreview(backgroundColor = Color.White, contentColor = Color.Black)
+  CodeBlockPreview(backgroundColor = Color.White, textColor = Color.Black)
 }
 
 @Preview @Composable
 private fun CodeBlockPreviewOnBlack() {
-  CodeBlockPreview(backgroundColor = Color.Black, contentColor = Color.White)
+  CodeBlockPreview(backgroundColor = Color.Black, textColor = Color.White)
 }
 
 @Composable
 private fun CodeBlockPreview(
   backgroundColor: Color,
-  contentColor: Color
+  textColor: Color
 ) {
-  CompositionLocalProvider(LocalContentColor provides contentColor) {
+  CompositionLocalProvider(LocalContentColor provides textColor) {
     Box(modifier = Modifier.background(color = backgroundColor)) {
       Box(modifier = Modifier.padding(24.dp)) {
         RichTextScope.CodeBlock(

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/Heading.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/Heading.kt
@@ -6,15 +6,10 @@ import androidx.annotation.IntRange
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.material.LocalContentColor
-import androidx.compose.material.LocalTextStyle
-import androidx.compose.material.ProvideTextStyle
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontStyle.Italic
@@ -76,7 +71,7 @@ internal val DefaultHeadingStyle: HeadingStyle = { level, textStyle ->
   text: String
 ) {
   Heading(level) {
-    Text(text)
+    BasicText(text)
   }
 }
 
@@ -94,6 +89,7 @@ internal val DefaultHeadingStyle: HeadingStyle = { level, textStyle ->
   val richTextStyle = currentRichTextStyle.resolveDefaults()
   val headingStyleFunction = richTextStyle.headingStyle!!
 
+  // Deprecated after removal of Material from base module
   // According to [Text] composable's documentation:
   //   "Additionally, for [color], if [color] is not set, and [style] does not have a color, then
   //   [AmbientContentColor] will be used - this allows this [Text] or element containing this [Text]
@@ -101,32 +97,34 @@ internal val DefaultHeadingStyle: HeadingStyle = { level, textStyle ->
   // However, [resolveDefaults] uses a static default color which is [Color.Black].
   // To fix this issue, we are specifying the text color according to [Text] documentation
   // before calling [resolveDefaults].
-  val incomingStyle = LocalTextStyle.current.let {
-    it.copy(color = it.color.takeOrElse { LocalContentColor.current })
-  }
+
+  //  val incomingStyle = LocalTextStyle.current.let {
+  //    it.copy(color = it.color.takeOrElse { LocalContentColor.current })
+  //  }
+  val incomingStyle = currentBasicTextStyle
   val currentTextStyle = resolveDefaults(incomingStyle, LocalLayoutDirection.current)
 
   val headingTextStyle = headingStyleFunction(level, currentTextStyle)
   val mergedTextStyle = currentTextStyle.merge(headingTextStyle)
 
-  ProvideTextStyle(mergedTextStyle) {
+  ProvideBasicTextStyle(mergedTextStyle) {
     children()
   }
 }
 
 @Preview @Composable private fun HeadingPreviewOnWhite() {
-  HeadingPreview(backgroundColor = Color.White, contentColor = Color.Black)
+  HeadingPreview(backgroundColor = Color.White, textColor = Color.Black)
 }
 
 @Preview @Composable private fun HeadingPreviewOnBlack() {
-  HeadingPreview(backgroundColor = Color.Black, contentColor = Color.White)
+  HeadingPreview(backgroundColor = Color.Black, textColor = Color.White)
 }
 
 @Composable private fun HeadingPreview(
   backgroundColor: Color,
-  contentColor: Color
+  textColor: Color
 ) {
-  CompositionLocalProvider(LocalContentColor provides contentColor) {
+  CompositionLocalProvider(LocalContentColor provides textColor) {
     Box(Modifier.background(color = backgroundColor)) {
       Column {
         for (level in 0 until 10) {

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/HorizontalRule.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/HorizontalRule.kt
@@ -5,20 +5,49 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.LocalContentColor
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+
+/**
+ * Defines how [HorizontalRule]s are rendered.
+ *
+ * @param color The [Color] of a horizontal rule.
+ */
+@Immutable
+public data class HorizontalRuleStyle(
+  val color: Color? = null
+) {
+  public companion object {
+    public val Default: HorizontalRuleStyle = HorizontalRuleStyle()
+  }
+}
+
+internal val DefaultHorizontalRuleColor: Color = Color.LightGray.copy(alpha = .5f)
+
+internal fun HorizontalRuleStyle.resolveDefaults() = HorizontalRuleStyle(
+  color = color ?: DefaultHorizontalRuleColor
+)
+
 
 /**
  * A simple horizontal line drawn with the current content color.
  */
 @Composable public fun RichTextScope.HorizontalRule() {
-  val color = LocalContentColor.current.copy(alpha = .2f)
-  val spacing = with(LocalDensity.current) {
-    currentRichTextStyle.resolveDefaults().paragraphSpacing!!.toDp()
+  var color: Color
+  var spacing: Dp
+
+  with(currentRichTextStyle.resolveDefaults()) {
+    color = horizontalRuleStyle!!.resolveDefaults().color!!
+    spacing = with(LocalDensity.current) {
+      paragraphSpacing!!.toDp()
+    }
   }
+
   Box(
     Modifier
       .padding(top = spacing, bottom = spacing)

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/RichTextScope.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/RichTextScope.kt
@@ -5,6 +5,8 @@ package com.zachklipp.richtext.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.text.TextStyle
 
 /**
  * Scope object for composables that can draw rich text.
@@ -17,6 +19,14 @@ public object RichTextScope
  */
 public val RichTextScope.currentRichTextStyle: RichTextStyle
   @Composable get() = LocalRichTextStyle.current
+
+/**
+ * The current [TextStyle].
+ */
+public val RichTextScope.currentBasicTextStyle: TextStyle
+  @Composable get() = with(LocalBasicTextStyle.current) {
+    copy(color = color.takeOrElse { LocalContentColor.current })
+  }
 
 /**
  * Sets the [RichTextStyle] for its [children].
@@ -34,4 +44,19 @@ public fun RichTextScope.WithStyle(
       children()
     }
   }
+}
+
+/**
+ * Some RichText components receive `text: String` parameters and directly
+ * render the content as a comfortable alternative to `@Composable` block.
+ *
+ * These components use [androidx.compose.foundation.text.BasicText] to render
+ * the received content. However, BasicText has no notion of provided text style.
+ *
+ * [RichTextScope.BasicText] provides an alternative BasicText which takes
+ * [currentRichTextStyle] into consideration. It's only meant for internal usage.
+ */
+@Composable
+internal fun RichTextScope.BasicText(text: String) {
+  androidx.compose.foundation.text.BasicText(text = text, style = currentBasicTextStyle)
 }

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/RichTextStyle.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/RichTextStyle.kt
@@ -1,13 +1,21 @@
 package com.zachklipp.richtext.ui
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
 import com.zachklipp.richtext.ui.string.RichTextStringStyle
 
 internal val LocalRichTextStyle = compositionLocalOf { RichTextStyle.Default }
+internal val LocalBasicTextStyle = compositionLocalOf { TextStyle.Default }
+internal val LocalContentColor = compositionLocalOf { DefaultContentColor }
+
 internal val DefaultParagraphSpacing: TextUnit = 8.sp
+internal val DefaultContentColor: Color = Color.Black
 
 /**
  * Configures all formatting attributes for drawing rich text.
@@ -29,7 +37,8 @@ public data class RichTextStyle(
   val blockQuoteGutter: BlockQuoteGutter? = null,
   val codeBlockStyle: CodeBlockStyle? = null,
   val tableStyle: TableStyle? = null,
-  val stringStyle: RichTextStringStyle? = null
+  val stringStyle: RichTextStringStyle? = null,
+  val horizontalRuleStyle: HorizontalRuleStyle? = null
 ) {
   public companion object {
     public val Default: RichTextStyle = RichTextStyle()
@@ -43,7 +52,8 @@ public fun RichTextStyle.merge(otherStyle: RichTextStyle?): RichTextStyle = Rich
     blockQuoteGutter = otherStyle?.blockQuoteGutter ?: blockQuoteGutter,
     codeBlockStyle = otherStyle?.codeBlockStyle ?: codeBlockStyle,
     tableStyle = otherStyle?.tableStyle ?: tableStyle,
-    stringStyle = stringStyle?.merge(otherStyle?.stringStyle)
+    stringStyle = stringStyle?.merge(otherStyle?.stringStyle) ?: otherStyle?.stringStyle,
+    horizontalRuleStyle = otherStyle?.horizontalRuleStyle ?: horizontalRuleStyle
 )
 
 public fun RichTextStyle.resolveDefaults(): RichTextStyle = RichTextStyle(
@@ -53,5 +63,13 @@ public fun RichTextStyle.resolveDefaults(): RichTextStyle = RichTextStyle(
     blockQuoteGutter = blockQuoteGutter ?: DefaultBlockQuoteGutter,
     codeBlockStyle = (codeBlockStyle ?: CodeBlockStyle.Default).resolveDefaults(),
     tableStyle = (tableStyle ?: TableStyle.Default).resolveDefaults(),
-    stringStyle = (stringStyle ?: RichTextStringStyle.Default).resolveDefaults()
+    stringStyle = (stringStyle ?: RichTextStringStyle.Default).resolveDefaults(),
+    horizontalRuleStyle = (horizontalRuleStyle ?: HorizontalRuleStyle.Default).resolveDefaults()
 )
+
+@Composable
+internal fun ProvideBasicTextStyle(value: TextStyle?, content: @Composable () -> Unit) {
+  val basicTextStyle = LocalBasicTextStyle.current
+  val mergedStyle = basicTextStyle.merge(value)
+  CompositionLocalProvider(LocalBasicTextStyle provides mergedStyle, content = content)
+}

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/string/Text.kt
@@ -1,8 +1,7 @@
 package com.zachklipp.richtext.ui.string
 
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.material.LocalContentColor
-import androidx.compose.material.Text
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
@@ -17,9 +16,11 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Constraints
+import com.zachklipp.richtext.ui.BasicRichText
+import com.zachklipp.richtext.ui.LocalContentColor
 import com.zachklipp.richtext.ui.LocalRichTextStyle
-import com.zachklipp.richtext.ui.RichText
 import com.zachklipp.richtext.ui.RichTextScope
+import com.zachklipp.richtext.ui.currentBasicTextStyle
 import com.zachklipp.richtext.ui.string.RichTextString.Format
 import com.zachklipp.richtext.ui.string.RichTextString.Format.Bold
 import com.zachklipp.richtext.ui.string.RichTextString.Format.Link
@@ -28,7 +29,7 @@ private const val ZERO_WIDTH_CHAR = "\u200B"
 
 @Preview(showBackground = true)
 @Composable private fun TextPreview() {
-  RichText {
+  BasicRichText {
     Text(richTextString {
       append("I'm ")
       withFormat(Bold) {
@@ -43,6 +44,7 @@ private const val ZERO_WIDTH_CHAR = "\u200B"
  *
  * @sample com.zachklipp.richtext.ui.string.TextPreview
  */
+// TODO: A different name that wouldn't collide with Material Text.
 @Suppress("unused")
 @Composable
 public fun RichTextScope.Text(
@@ -93,8 +95,9 @@ public fun RichTextScope.Text(
   Layout(
     modifier = modifier.then(pressIndicator),
     content = {
-      Text(
+      BasicText(
         text = hack,
+        style = currentBasicTextStyle,
         onTextLayout = { result ->
           layoutResult.value = result
           onTextLayout(result)

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -7,6 +7,7 @@ dependencies {
   implementation project(':printing')
   implementation project(':richtext-commonmark')
   implementation project(':richtext-ui')
+  implementation project(':richtext-ui-material')
   implementation project(':slideshow')
   implementation deps.androidx.appcompat
   implementation deps.compose.activity

--- a/sample/src/main/java/com/zachklipp/richtext/sample/Demo.kt
+++ b/sample/src/main/java/com/zachklipp/richtext/sample/Demo.kt
@@ -10,6 +10,7 @@ import androidx.compose.material.LocalContentColor
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
@@ -22,10 +23,10 @@ import com.zachklipp.richtext.ui.HorizontalRule
 import com.zachklipp.richtext.ui.ListType
 import com.zachklipp.richtext.ui.ListType.Ordered
 import com.zachklipp.richtext.ui.ListType.Unordered
-import com.zachklipp.richtext.ui.RichText
 import com.zachklipp.richtext.ui.RichTextScope
 import com.zachklipp.richtext.ui.RichTextStyle
 import com.zachklipp.richtext.ui.Table
+import com.zachklipp.richtext.ui.material.RichText
 
 @Preview(widthDp = 300, heightDp = 1000)
 @Composable fun RichTextDemoOnWhite() {
@@ -45,11 +46,13 @@ import com.zachklipp.richtext.ui.Table
 
 @Composable fun RichTextDemo(
   style: RichTextStyle? = null,
-  header: String = ""
+  header: String = "",
+  alignment: Alignment.Horizontal = Alignment.Start
 ) {
   RichText(
     modifier = Modifier.padding(8.dp),
-    style = style
+    richTextStyle = style,
+    alignment = alignment
   ) {
     Heading(0, "Paragraphs $header")
     Text("Simple paragraph.")

--- a/sample/src/main/java/com/zachklipp/richtext/sample/DocumentSample.kt
+++ b/sample/src/main/java/com/zachklipp/richtext/sample/DocumentSample.kt
@@ -54,7 +54,7 @@ import androidx.compose.ui.unit.offset
 import androidx.compose.ui.unit.sp
 import com.zachklipp.richtext.ui.FormattedList
 import com.zachklipp.richtext.ui.ListType.Unordered
-import com.zachklipp.richtext.ui.RichText
+import com.zachklipp.richtext.ui.material.RichText
 import com.zachklipp.richtext.ui.printing.Printable
 import com.zachklipp.richtext.ui.printing.PrintableController
 import com.zachklipp.richtext.ui.printing.hideWhenPrinting

--- a/sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
+++ b/sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
@@ -17,16 +17,20 @@ import androidx.compose.material.Text
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.zachklipp.richtext.markdown.Markdown
 import com.zachklipp.richtext.ui.RichTextStyle
+import com.zachklipp.richtext.ui.material.RichText
 import com.zachklipp.richtext.ui.resolveDefaults
 
 @Preview
@@ -40,6 +44,14 @@ import com.zachklipp.richtext.ui.resolveDefaults
 
   val colors = if (isDarkModeEnabled) darkColors() else lightColors()
   val context = LocalContext.current
+
+  val sampleUriHandler = remember(context) {
+    object: UriHandler {
+      override fun openUri(uri: String) {
+        Toast.makeText(context, uri, Toast.LENGTH_SHORT).show()
+      }
+    }
+  }
 
   MaterialTheme(colors = colors) {
     Surface {
@@ -69,14 +81,14 @@ import com.zachklipp.richtext.ui.resolveDefaults
 
         SelectionContainer {
           Column(Modifier.verticalScroll(rememberScrollState())) {
-            Markdown(
-              content = sampleMarkdown,
-              style = richTextStyle,
-              modifier = Modifier.padding(8.dp),
-              onLinkClicked = {
-                Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
+            CompositionLocalProvider(LocalUriHandler provides sampleUriHandler) {
+              RichText(
+                richTextStyle = richTextStyle,
+                modifier = Modifier.padding(8.dp)
+              ) {
+                Markdown(sampleMarkdown)
               }
-            )
+            }
           }
         }
       }

--- a/sample/src/main/java/com/zachklipp/richtext/sample/RichTextSample.kt
+++ b/sample/src/main/java/com/zachklipp/richtext/sample/RichTextSample.kt
@@ -4,23 +4,31 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Card
 import androidx.compose.material.Checkbox
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Slider
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.darkColors
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FormatAlignCenter
+import androidx.compose.material.icons.filled.FormatAlignLeft
+import androidx.compose.material.icons.filled.FormatAlignRight
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -36,6 +44,7 @@ import com.zachklipp.richtext.ui.resolveDefaults
 @Composable fun RichTextSample() {
   var richTextStyle by remember { mutableStateOf(RichTextStyle().resolveDefaults()) }
   var isDarkModeEnabled by remember { mutableStateOf(false) }
+  var alignment by remember { mutableStateOf(Alignment.Start) }
 
   val colors = if (isDarkModeEnabled) darkColors() else lightColors()
 
@@ -57,17 +66,29 @@ import com.zachklipp.richtext.ui.resolveDefaults
 
                 )
               Text("Dark Mode")
+
+              Spacer(modifier = Modifier.weight(1f))
+
+              IconButton(onClick = { alignment = Alignment.Start }) {
+                Icon(Icons.Default.FormatAlignLeft, contentDescription = "Align Start")
+              }
+              IconButton(onClick = { alignment = Alignment.CenterHorizontally }) {
+                Icon(Icons.Default.FormatAlignCenter, contentDescription = "Align Center")
+              }
+              IconButton(onClick = { alignment = Alignment.End }) {
+                Icon(Icons.Default.FormatAlignRight, contentDescription = "Align End")
+              }
             }
             RichTextStyleConfig(
               richTextStyle = richTextStyle,
-              onChanged = { richTextStyle = it }
+              onChanged = { richTextStyle = it },
             )
           }
         }
 
         SelectionContainer {
           Column(Modifier.verticalScroll(rememberScrollState())) {
-            RichTextDemo(style = richTextStyle)
+            RichTextDemo(style = richTextStyle, alignment = alignment)
           }
         }
       }

--- a/sample/src/main/java/com/zachklipp/richtext/sample/SlideshowSample.kt
+++ b/sample/src/main/java/com/zachklipp/richtext/sample/SlideshowSample.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import com.zachklipp.richtext.ui.FormattedList
 import com.zachklipp.richtext.ui.ListType.Ordered
-import com.zachklipp.richtext.ui.RichText
+import com.zachklipp.richtext.ui.material.RichText
 import com.zachklipp.richtext.ui.slideshow.BodySlide
 import com.zachklipp.richtext.ui.slideshow.NavigableContentContainer
 import com.zachklipp.richtext.ui.slideshow.SlideDivider

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,7 @@ pluginManagement {
 
 include ':printing'
 include ':richtext-ui'
+include ':richtext-ui-material'
 include ':richtext-commonmark'
 include ':sample'
 include ':slideshow'


### PR DESCRIPTION
- Following the compose text standards, richtext-ui is now split into two artifacts.
- RichText ➡ BasicRichText. New RichText named composable can be found in richtext-ui-material
- Added LocalBasicTextStyle that should mimic the abilities of LocalTextStyle from compose.material
- Added LocalContentColor that should mimic the abilities of LocalContentColor from compose.material
- Completely removed material dependency from richtext-ui
- Added new configuration options to BasicRichText
  - Alignment: Used to horizontally align content in the main column
  - TextStyle: No longer retrievable from LocalTextStyle, textStyle now has to be provided explicitly.
  - Color: No longer retrievable from LocalContentColor, contentColor now has to be provided explicitly.
- Updated Markdown artifact to reflect the changes.
  - Markdown is no longer a standalone composable due to increased customization of BasicRichText. Instead, Markdown is just another component under RichTextScope. This change should also increase the visibility of Markdown's dependence on richtext-ui
  - Introduced MarkdownConfiguration. Markdown rendering sometimes requires granular control over individual components such as Images and HTML blocks.
  - Removed onLinkClicked argument. Although LocalUriHandler dependency is implicit, adding visibility to this CompositionLocal might benefit the users in the long run.
- Removed material references from all previews under richtext-ui