### PR TITLE
Remove Material dependency from RichText

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@
 buildscript {
   ext.versions = [
       targetSdk: 29,
-      compose: '1.0.0-beta07',
-      kotlin: '1.4.32',
+      compose: '1.0.0-beta09',
+      kotlin: '1.5.10',
       commonmark: '0.15.2'
   ]
 
@@ -32,7 +32,7 @@ buildscript {
   }
 
   ext.deps = [
-      android_gradle_plugin: "com.android.tools.build:gradle:7.1.0-alpha01",
+      android_gradle_plugin: "com.android.tools.build:gradle:7.1.0-alpha02",
 
       androidx: [
           activity: "androidx.activity:activity:1.1.0",
@@ -51,7 +51,7 @@ buildscript {
           viewbinding: "androidx.databinding:viewbinding:3.6.1",
       ],
       compose: [
-          activity: "androidx.activity:activity-compose:1.3.0-alpha08",
+          activity: "androidx.activity:activity-compose:1.3.0-beta02",
           foundation: "androidx.compose.foundation:foundation:${versions.compose}",
           layout: "androidx.compose.foundation:foundation-layout:${versions.compose}",
           material: "androidx.compose.material:material:${versions.compose}",

--- a/printing/src/main/java/com/zachklipp/richtext/ui/printing/Paged.kt
+++ b/printing/src/main/java/com/zachklipp/richtext/ui/printing/Paged.kt
@@ -370,7 +370,7 @@ private fun DrawScope.drawBreakpoints(
     val childConstraints = constraints.copy(maxHeight = Int.MAX_VALUE)
     val placeables = measurables.map { it.measure(childConstraints) }
     val maxChildWidth = placeables.maxOfOrNull { it.width } ?: 0
-    val totalChildHeight = placeables.sumBy { it.height }
+    val totalChildHeight = placeables.sumOf { it.height }
 
     val actualWidth = constraints.constrainWidth(maxChildWidth)
     val actualHeight = constraints.constrainHeight(totalChildHeight)

--- a/printing/src/main/java/com/zachklipp/richtext/ui/printing/PrinterMetrics.kt
+++ b/printing/src/main/java/com/zachklipp/richtext/ui/printing/PrinterMetrics.kt
@@ -13,7 +13,8 @@ private const val DP_DPI = 160
 public const val DefaultPageDpi: Int = 100
 
 /** Represents a PostScript point (1/72 of an inch). */
-internal inline class Pts(val value: Int) {
+@JvmInline
+internal value class Pts(val value: Int) {
   override fun toString(): String = "$value.pts"
 }
 

--- a/richtext-commonmark/api/richtext-commonmark.api
+++ b/richtext-commonmark/api/richtext-commonmark.api
@@ -15,6 +15,6 @@ public final class com/zachklipp/richtext/markdown/ComposableSingletons$Markdown
 }
 
 public final class com/zachklipp/richtext/markdown/MarkdownKt {
-	public static final fun Markdown (Ljava/lang/String;Landroidx/compose/ui/Modifier;Lcom/zachklipp/richtext/ui/RichTextStyle;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun Markdown (Lcom/zachklipp/richtext/ui/RichTextScope;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 }
 

--- a/richtext-commonmark/src/main/java/com/zachklipp/richtext/markdown/Markdown.kt
+++ b/richtext-commonmark/src/main/java/com/zachklipp/richtext/markdown/Markdown.kt
@@ -31,35 +31,27 @@ import org.commonmark.ext.gfm.tables.TablesExtension
 import org.commonmark.parser.Parser
 
 /**
- * A composable that renders Markdown content using [RichText].
+ * A composable that renders Markdown content inside [RichText].
  *
- * @param content Markdown text. No restriction on length.
- * @param style [RichTextStyle] that will be used to style markdown rendering.
- * @param onLinkClicked A function to invoke when a link is clicked from rendered content.
+ * @param content Markdown text.
+ * @param onLinkClicked A callback for when a link is clicked from rendered content.
  */
 @Composable
-public fun Markdown(
+public fun RichTextScope.Markdown(
   content: String,
-  modifier: Modifier = Modifier,
-  style: RichTextStyle? = null,
   onLinkClicked: ((String) -> Unit)? = null
 ) {
-  RichText(
-    modifier = modifier,
-    style = style
-  ) {
-    // Can't use UriHandlerAmbient.current::openUri here,
-    // see https://issuetracker.google.com/issues/172366483
-    val realLinkClickedHandler = onLinkClicked ?: LocalUriHandler.current.let {
-      remember {
-        { url -> it.openUri(url) }
-      }
+  // Can't use UriHandlerAmbient.current::openUri here,
+  // see https://issuetracker.google.com/issues/172366483
+  val realLinkClickedHandler = onLinkClicked ?: LocalUriHandler.current.let {
+    remember {
+      { url -> it.openUri(url) }
     }
+  }
 
-    CompositionLocalProvider(LocalOnLinkClicked provides realLinkClickedHandler) {
-      val markdownAst = parsedMarkdownAst(text = content)
-      RecursiveRenderMarkdownAst(astNode = markdownAst)
-    }
+  CompositionLocalProvider(LocalOnLinkClicked provides realLinkClickedHandler) {
+    val markdownAst = parsedMarkdownAst(text = content)
+    RecursiveRenderMarkdownAst(astNode = markdownAst)
   }
 }
 

--- a/richtext-ui-material/api/richtext-ui-material.api
+++ b/richtext-ui-material/api/richtext-ui-material.api
@@ -1,0 +1,11 @@
+public final class com/zachklipp/richtext/ui/material/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public final class com/zachklipp/richtext/ui/material/MaterialRichTextKt {
+	public static final fun ProvideMaterialThemingToRichText (Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+}
+

--- a/richtext-ui-material/build.gradle
+++ b/richtext-ui-material/build.gradle
@@ -5,11 +5,7 @@ apply from: rootProject.file('gradle/maven-publish.gradle')
 android rootProject.ext.defaultAndroidConfig
 
 dependencies {
-  compileOnly deps.compose.tooling
 
-  api deps.androidx.annotations
-  api deps.compose.foundation
-
-  // TODO Migrate off this.
-//  implementation deps.compose.material
+  api project(':richtext-ui')
+  implementation deps.compose.material
 }

--- a/richtext-ui-material/gradle.properties
+++ b/richtext-ui-material/gradle.properties
@@ -1,0 +1,4 @@
+POM_ARTIFACT_ID=richtext-ui-material
+POM_NAME=Compose Richtext UI Material
+POM_DESCRIPTION=A library for binding Material theming to RichText
+POM_PACKAGING=aar

--- a/richtext-ui-material/proguard-rules.pro
+++ b/richtext-ui-material/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/richtext-ui-material/src/main/AndroidManifest.xml
+++ b/richtext-ui-material/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.zachklipp.richtext.ui.material" />

--- a/richtext-ui-material/src/main/java/com/zachklipp/richtext/ui/material/MaterialRichText.kt
+++ b/richtext-ui-material/src/main/java/com/zachklipp/richtext/ui/material/MaterialRichText.kt
@@ -1,0 +1,15 @@
+package com.zachklipp.richtext.ui.material
+
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.LocalTextStyle
+import androidx.compose.runtime.Composable
+import com.zachklipp.richtext.ui.ProvideRichTextLocals
+
+@Composable
+public fun ProvideMaterialThemingToRichText(
+  content: @Composable () -> Unit
+) {
+  ProvideRichTextLocals(localTextStyle = LocalTextStyle, localContentColor = LocalContentColor) {
+    content()
+  }
+}

--- a/richtext-ui/api/richtext-ui.api
+++ b/richtext-ui/api/richtext-ui.api
@@ -151,6 +151,26 @@ public final class com/zachklipp/richtext/ui/RichTextKt {
 	public static final fun RichText (Landroidx/compose/ui/Modifier;Lcom/zachklipp/richtext/ui/RichTextStyle;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 }
 
+public final class com/zachklipp/richtext/ui/RichTextLocals {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/runtime/ProvidableCompositionLocal;Landroidx/compose/runtime/ProvidableCompositionLocal;)V
+	public final fun component1 ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+	public final fun component2 ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+	public final fun copy (Landroidx/compose/runtime/ProvidableCompositionLocal;Landroidx/compose/runtime/ProvidableCompositionLocal;)Lcom/zachklipp/richtext/ui/RichTextLocals;
+	public static synthetic fun copy$default (Lcom/zachklipp/richtext/ui/RichTextLocals;Landroidx/compose/runtime/ProvidableCompositionLocal;Landroidx/compose/runtime/ProvidableCompositionLocal;ILjava/lang/Object;)Lcom/zachklipp/richtext/ui/RichTextLocals;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLocalContentColor ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+	public final fun getLocalTextStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/zachklipp/richtext/ui/RichTextLocalsKt {
+	public static final fun ProvideRichTextLocals (Landroidx/compose/runtime/ProvidableCompositionLocal;Landroidx/compose/runtime/ProvidableCompositionLocal;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+	public static final fun getCurrentContentColor (Lcom/zachklipp/richtext/ui/RichTextScope;Landroidx/compose/runtime/Composer;I)J
+	public static final fun getCurrentTextStyle (Lcom/zachklipp/richtext/ui/RichTextScope;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/text/TextStyle;
+}
+
 public final class com/zachklipp/richtext/ui/RichTextScope {
 	public static final field INSTANCE Lcom/zachklipp/richtext/ui/RichTextScope;
 }
@@ -249,8 +269,8 @@ public final class com/zachklipp/richtext/ui/string/ComposableSingletons$TextKt 
 
 public final class com/zachklipp/richtext/ui/string/InlineContent {
 	public static final field $stable I
-	public fun <init> (Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/text/PlaceholderVerticalAlign;Lkotlin/jvm/functions/Function4;)V
-	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/text/PlaceholderVerticalAlign;Lkotlin/jvm/functions/Function4;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;ILkotlin/jvm/functions/Function4;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;ILkotlin/jvm/functions/Function4;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/zachklipp/richtext/ui/string/RichTextString {
@@ -284,6 +304,7 @@ public final class com/zachklipp/richtext/ui/string/RichTextString$Builder {
 public abstract class com/zachklipp/richtext/ui/string/RichTextString$Format {
 	public static final field $stable I
 	public static final field Companion Lcom/zachklipp/richtext/ui/string/RichTextString$Format$Companion;
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/BlockQuote.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/BlockQuote.kt
@@ -7,8 +7,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.LocalContentColor
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
@@ -23,6 +21,7 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.offset
 import androidx.compose.ui.unit.sp
 import com.zachklipp.richtext.ui.BlockQuoteGutter.BarGutter
+import com.zachklipp.richtext.ui.string.InternalText
 
 internal val DefaultBlockQuoteGutter = BarGutter()
 
@@ -44,7 +43,7 @@ public interface BlockQuoteGutter {
   ) : BlockQuoteGutter {
     @Composable override fun drawGutter() {
       with(LocalDensity.current) {
-        val color = color(LocalContentColor.current)
+        val color = color(RichTextScope.currentContentColor)
         val modifier = remember(startMargin, endMargin, barWidth, color) {
           // Padding must come before width.
           Modifier
@@ -121,13 +120,13 @@ public interface BlockQuoteGutter {
   backgroundColor: Color,
   contentColor: Color
 ) {
-  CompositionLocalProvider(LocalContentColor provides contentColor) {
+  BasicLocalsProvider(contentColor = contentColor) {
     Box(Modifier.background(backgroundColor)) {
       RichTextScope.BlockQuote {
-        Text("Some text.")
-        Text("Another paragraph.")
+        InternalText("Some text.")
+        InternalText("Another paragraph.")
         BlockQuote {
-          Text("Nested block quote.")
+          InternalText("Nested block quote.")
         }
       }
     }

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/CodeBlock.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/CodeBlock.kt
@@ -5,11 +5,6 @@ package com.zachklipp.richtext.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.BasicText
-import androidx.compose.material.LocalContentColor
-import androidx.compose.material.LocalTextStyle
-import androidx.compose.material.ProvideTextStyle
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
@@ -22,6 +17,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.zachklipp.richtext.ui.string.InternalText
 
 /**
  * Defines how [CodeBlock]s are rendered.
@@ -60,7 +56,7 @@ internal fun CodeBlockStyle.resolveDefaults() = CodeBlockStyle(
  */
 @Composable public fun RichTextScope.CodeBlock(text: String) {
   CodeBlock {
-    Text(text)
+    InternalText(text)
   }
 }
 
@@ -70,7 +66,7 @@ internal fun CodeBlockStyle.resolveDefaults() = CodeBlockStyle(
  */
 @Composable public fun RichTextScope.CodeBlock(children: @Composable RichTextScope.() -> Unit) {
   val richTextStyle = currentRichTextStyle.resolveDefaults().codeBlockStyle!!
-  val textStyle = LocalTextStyle.current.merge(richTextStyle.textStyle)
+  val textStyle = currentTextStyle.merge(richTextStyle.textStyle)
   val background = Modifier.background(color = richTextStyle.background!!)
   val blockPadding = with(LocalDensity.current) {
     richTextStyle.padding!!.toDp()
@@ -79,7 +75,7 @@ internal fun CodeBlockStyle.resolveDefaults() = CodeBlockStyle(
   Box(modifier = background) {
     // Can't use Box(padding=) because that property doesn't seem affect the intrinsic size.
     Box(Modifier.padding(blockPadding)) {
-      ProvideTextStyle(textStyle) {
+      CompositionLocalProvider(LocalRichTextLocals.current.localTextStyle provides textStyle) {
         children()
       }
     }
@@ -101,7 +97,7 @@ private fun CodeBlockPreview(
   backgroundColor: Color,
   contentColor: Color
 ) {
-  CompositionLocalProvider(LocalContentColor provides contentColor) {
+  BasicLocalsProvider(contentColor = contentColor) {
     Box(modifier = Modifier.background(color = backgroundColor)) {
       Box(modifier = Modifier.padding(24.dp)) {
         RichTextScope.CodeBlock(

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/FormattedList.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/FormattedList.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.selection.DisableSelection
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
@@ -17,9 +16,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.paint
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.text.resolveDefaults
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.IntSize
@@ -28,6 +29,7 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
 import com.zachklipp.richtext.ui.ListType.Ordered
 import com.zachklipp.richtext.ui.ListType.Unordered
+import com.zachklipp.richtext.ui.string.InternalText
 import kotlin.math.max
 
 public enum class ListType {
@@ -60,7 +62,7 @@ public interface OrderedMarkers {
      */
     public fun text(vararg markers: (index: Int) -> String): OrderedMarkers =
       OrderedMarkers { level, index ->
-        Text(markers[level % markers.size](index))
+        RichTextScope.InternalText(markers[level % markers.size](index))
       }
 
     /**
@@ -94,7 +96,7 @@ public interface UnorderedMarkers {
      * indentation level.
      */
     public fun text(vararg markers: String): UnorderedMarkers = UnorderedMarkers {
-      Text(markers[it % markers.size])
+      RichTextScope.InternalText(markers[it % markers.size])
     }
 
     /**
@@ -264,7 +266,7 @@ private val ListLevelAmbient = compositionLocalOf { 0 }
     val widestItem = itemPlaceables.maxByOrNull { it.width }!!
 
     val listWidth = widestPrefix.width + widestItem.width
-    val listHeight = itemPlaceables.sumBy { it.height }
+    val listHeight = itemPlaceables.sumOf { it.height }
     layout(listWidth, listHeight) {
       var y = 0
 
@@ -333,14 +335,14 @@ private val ListLevelAmbient = compositionLocalOf { 0 }
         ).withIndex()
           .toList()
       ) { (index, text) ->
-        Text(text)
+        InternalText(text)
         if (index == 0) {
           FormattedList(listType, @Composable() {
-            Text("indented $text")
+            InternalText("indented $text")
             FormattedList(listType, @Composable() {
-              Text("indented $text")
+              InternalText("indented $text")
               FormattedList(listType, @Composable() {
-                Text("indented $text")
+                InternalText("indented $text")
               })
             })
           })

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/Heading.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/Heading.kt
@@ -6,10 +6,6 @@ import androidx.annotation.IntRange
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.material.LocalContentColor
-import androidx.compose.material.LocalTextStyle
-import androidx.compose.material.ProvideTextStyle
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
@@ -17,11 +13,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontStyle.Italic
+import androidx.compose.ui.text.font.FontStyle.Companion.Italic
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.resolveDefaults
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
+import com.zachklipp.richtext.ui.string.InternalText
 
 /**
  * Function that computes the [TextStyle] for the given header level, given the current [TextStyle]
@@ -76,7 +73,7 @@ internal val DefaultHeadingStyle: HeadingStyle = { level, textStyle ->
   text: String
 ) {
   Heading(level) {
-    Text(text)
+    InternalText(text)
   }
 }
 
@@ -101,15 +98,15 @@ internal val DefaultHeadingStyle: HeadingStyle = { level, textStyle ->
   // However, [resolveDefaults] uses a static default color which is [Color.Black].
   // To fix this issue, we are specifying the text color according to [Text] documentation
   // before calling [resolveDefaults].
-  val incomingStyle = LocalTextStyle.current.let {
-    it.copy(color = it.color.takeOrElse { LocalContentColor.current })
+  val incomingStyle = currentTextStyle.let {
+    it.copy(color = it.color.takeOrElse { currentContentColor })
   }
-  val currentTextStyle = resolveDefaults(incomingStyle, LocalLayoutDirection.current)
+  val updatedTextStyle = resolveDefaults(incomingStyle, LocalLayoutDirection.current)
 
-  val headingTextStyle = headingStyleFunction(level, currentTextStyle)
-  val mergedTextStyle = currentTextStyle.merge(headingTextStyle)
+  val headingTextStyle = headingStyleFunction(level, updatedTextStyle)
+  val mergedTextStyle = updatedTextStyle.merge(headingTextStyle)
 
-  ProvideTextStyle(mergedTextStyle) {
+  CompositionLocalProvider(LocalRichTextLocals.current.localTextStyle provides mergedTextStyle) {
     children()
   }
 }
@@ -126,7 +123,7 @@ internal val DefaultHeadingStyle: HeadingStyle = { level, textStyle ->
   backgroundColor: Color,
   contentColor: Color
 ) {
-  CompositionLocalProvider(LocalContentColor provides contentColor) {
+  BasicLocalsProvider(contentColor = contentColor) {
     Box(Modifier.background(color = backgroundColor)) {
       Column {
         for (level in 0 until 10) {

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/HorizontalRule.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/HorizontalRule.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.LocalContentColor
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
@@ -15,7 +14,7 @@ import androidx.compose.ui.unit.dp
  * A simple horizontal line drawn with the current content color.
  */
 @Composable public fun RichTextScope.HorizontalRule() {
-  val color = LocalContentColor.current.copy(alpha = .2f)
+  val color = currentContentColor.copy(alpha = .2f)
   val spacing = with(LocalDensity.current) {
     currentRichTextStyle.resolveDefaults().paragraphSpacing!!.toDp()
   }

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/RichTextLocals.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/RichTextLocals.kt
@@ -1,0 +1,77 @@
+package com.zachklipp.richtext.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.CompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.TextStyle.Companion
+
+/**
+ * Provides necessary [CompositionLocal] objects for RichText.
+ *
+ * This function should be called at the start of Compose hierarchy near to Theming
+ * declaration. [RichText] exclusively uses these [CompositionLocal] objects. Please
+ * refer to [RichTextLocals] for more info.
+ */
+@Composable
+public fun ProvideRichTextLocals(
+  localTextStyle: ProvidableCompositionLocal<TextStyle>,
+  localContentColor: ProvidableCompositionLocal<Color>,
+  content: @Composable () -> Unit
+) {
+  CompositionLocalProvider(
+    LocalRichTextLocals provides RichTextLocals(localTextStyle, localContentColor),
+    content = content
+  )
+}
+
+/**
+ * A stable class that holds [CompositionLocal]s that provide [TextStyle] and content [Color].
+ *
+ * This class is intended to be used in conjunction with [ProvideRichTextLocals]. Once these
+ * locals are provided, [RichText] can understand the current text style as well as
+ * modify it in accordance with [RichTextStyle] that can be defined at each [RichText] call.
+ */
+public data class RichTextLocals(
+  val localTextStyle: ProvidableCompositionLocal<TextStyle>,
+  val localContentColor: ProvidableCompositionLocal<Color>
+)
+
+internal val LocalRichTextLocals = staticCompositionLocalOf {
+  RichTextLocals(
+    localTextStyle = compositionLocalOf { TextStyle.Default },
+    localContentColor = compositionLocalOf { Color.White },
+  )
+}
+
+/**
+ * The current [TextStyle].
+ */
+public val RichTextScope.currentTextStyle: TextStyle
+  @Composable get() = LocalRichTextLocals.current.localTextStyle.current
+
+/**
+ * The current content [Color].
+ */
+public val RichTextScope.currentContentColor: Color
+  @Composable get() = LocalRichTextLocals.current.localContentColor.current
+
+/**
+ * Intended only for internal use to quickly provide these locals when necessary.
+ */
+@Composable
+internal fun BasicLocalsProvider(
+  textStyle: TextStyle = TextStyle.Default,
+  contentColor: Color = Color.White,
+  content: @Composable () -> Unit
+) {
+  ProvideRichTextLocals(
+    localTextStyle = compositionLocalOf { textStyle },
+    localContentColor = compositionLocalOf { contentColor },
+    content = content
+  )
+}

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/SimpleTableLayout.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/SimpleTableLayout.kt
@@ -71,7 +71,7 @@ internal fun SimpleTableLayout(
     val rowHeights = rowPlaceables.map { row -> row.maxByOrNull { it.height }!!.height }
 
     val tableWidth = constraints.maxWidth
-    val tableHeight = (rowHeights.sumBy { it } + cellSpacingHeight).roundToInt()
+    val tableHeight = (rowHeights.sumOf { it } + cellSpacingHeight).roundToInt()
     layout(tableWidth, tableHeight) {
       var y = cellSpacing
       val rowOffsets = mutableListOf<Float>()

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/Table.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/Table.kt
@@ -4,10 +4,8 @@ package com.zachklipp.richtext.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.LocalTextStyle
-import androidx.compose.material.ProvideTextStyle
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -22,6 +20,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.zachklipp.richtext.ui.string.InternalText
 import kotlin.math.max
 
 /**
@@ -108,13 +107,13 @@ public fun RichTextScope.Table(
         rows.maxByOrNull { it.cells.size }?.cells?.size ?: 0
     )
   }
-  val headerStyle = LocalTextStyle.current.merge(tableStyle.headerTextStyle)
+  val headerStyle = currentTextStyle.merge(tableStyle.headerTextStyle)
   val cellPadding = with(LocalDensity.current) {
     tableStyle.cellPadding!!.toDp()
   }
   val cellModifier = Modifier
-      .clipToBounds()
-      .padding(cellPadding)
+    .clipToBounds()
+    .padding(cellPadding)
 
   val styledRows = remember(header, rows, cellModifier) {
     buildList {
@@ -123,7 +122,7 @@ public fun RichTextScope.Table(
         @Suppress("RemoveExplicitTypeArguments")
         add(headerRow.cells.map<@Composable RichTextScope.() -> Unit, @Composable () -> Unit> { cell ->
           @Composable {
-            ProvideTextStyle(headerStyle) {
+            CompositionLocalProvider(LocalRichTextLocals.current.localTextStyle provides headerStyle) {
               RichText(modifier = cellModifier, children = cell)
             }
           }
@@ -204,12 +203,12 @@ private fun TablePreviewContents(modifier: Modifier = Modifier) {
           .background(Color.White)
           .padding(4.dp),
       headerRow = {
-        cell { Text("Column 1") }
-        cell { Text("Column 2") }
+        cell { InternalText("Column 1") }
+        cell { InternalText("Column 2") }
       }
   ) {
     row {
-      cell { Text("Hello") }
+      cell { InternalText("Hello") }
       cell {
         CodeBlock("Foo bar")
       }
@@ -217,10 +216,10 @@ private fun TablePreviewContents(modifier: Modifier = Modifier) {
     row {
       cell {
         BlockQuote {
-          Text("Stuff")
+          InternalText("Stuff")
         }
       }
-      cell { Text("Hello world this is a really long line that is going to wrap hopefully") }
+      cell { InternalText("Hello world this is a really long line that is going to wrap hopefully") }
     }
   }
 }

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/string/InlineContent.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/string/InlineContent.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
-import androidx.compose.ui.text.PlaceholderVerticalAlign.AboveBaseline
+import androidx.compose.ui.text.PlaceholderVerticalAlign.Companion.AboveBaseline
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/string/InternalText.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/string/InternalText.kt
@@ -1,0 +1,80 @@
+package com.zachklipp.richtext.ui.string
+
+import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.foundation.text.BasicText as ComposeBasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.resolveDefaults
+import androidx.compose.ui.text.style.TextOverflow
+import com.zachklipp.richtext.ui.RichTextScope
+import com.zachklipp.richtext.ui.currentContentColor
+import com.zachklipp.richtext.ui.currentTextStyle
+
+/**
+ * This composable is mostly used by Previews as well as public Composables which take String as
+ * a direct argument instead of children Composable.
+ *
+ * [InternalText] is created because Material Text is not available and calling BasicText would
+ * require each time to add `style = currentTextStyle`
+ *
+ * Arguments are taken directly from [ComposeBasicText] with the exception of [TextStyle]
+ */
+@Composable
+internal fun RichTextScope.InternalText(
+  text: String,
+  modifier: Modifier = Modifier,
+  onTextLayout: (TextLayoutResult) -> Unit = {},
+  overflow: TextOverflow = TextOverflow.Clip,
+  softWrap: Boolean = true,
+  maxLines: Int = Int.MAX_VALUE,
+) {
+  InternalText(
+    AnnotatedString(text),
+    modifier,
+    onTextLayout,
+    overflow,
+    softWrap,
+    maxLines
+  )
+}
+
+/**
+ * This composable is mostly used by Previews as well as public Composables which take String as
+ * a direct argument instead of children Composable.
+ *
+ * [InternalText] is created because Material Text is not available and calling BasicText would
+ * require each time to add `style = currentTextStyle`
+ *
+ * Arguments are taken directly from [ComposeBasicText] with the exception of [TextStyle]
+ */
+@Composable
+internal fun RichTextScope.InternalText(
+  text: AnnotatedString,
+  modifier: Modifier = Modifier,
+  onTextLayout: (TextLayoutResult) -> Unit = {},
+  overflow: TextOverflow = TextOverflow.Clip,
+  softWrap: Boolean = true,
+  maxLines: Int = Int.MAX_VALUE,
+  inlineContent: Map<String, InlineTextContent> = mapOf(),
+) {
+  val incomingStyle = currentTextStyle.let {
+    it.copy(color = it.color.takeOrElse { currentContentColor })
+  }
+  val updatedTextStyle = resolveDefaults(incomingStyle, LocalLayoutDirection.current)
+
+  ComposeBasicText(
+    text = text,
+    modifier = modifier,
+    style = updatedTextStyle,
+    onTextLayout = onTextLayout,
+    overflow = overflow,
+    softWrap = softWrap,
+    maxLines = maxLines,
+    inlineContent = inlineContent
+  )
+}

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/string/Text.kt
@@ -1,8 +1,6 @@
 package com.zachklipp.richtext.ui.string
 
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.material.LocalContentColor
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
@@ -20,6 +18,7 @@ import androidx.compose.ui.unit.Constraints
 import com.zachklipp.richtext.ui.LocalRichTextStyle
 import com.zachklipp.richtext.ui.RichText
 import com.zachklipp.richtext.ui.RichTextScope
+import com.zachklipp.richtext.ui.currentContentColor
 import com.zachklipp.richtext.ui.string.RichTextString.Format
 import com.zachklipp.richtext.ui.string.RichTextString.Format.Bold
 import com.zachklipp.richtext.ui.string.RichTextString.Format.Link
@@ -51,7 +50,7 @@ public fun RichTextScope.Text(
   onTextLayout: (TextLayoutResult) -> Unit = {}
 ) {
   val style = LocalRichTextStyle.current.stringStyle
-  val contentColor = LocalContentColor.current
+  val contentColor = currentContentColor
   val annotated = remember(text, style, contentColor) {
     val resolvedStyle = (style ?: RichTextStringStyle.Default).resolveDefaults()
     text.toAnnotatedString(resolvedStyle, contentColor)
@@ -93,7 +92,7 @@ public fun RichTextScope.Text(
   Layout(
     modifier = modifier.then(pressIndicator),
     content = {
-      Text(
+      InternalText(
         text = hack,
         onTextLayout = { result ->
           layoutResult.value = result

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -6,7 +6,7 @@ android rootProject.ext.defaultAndroidConfig
 dependencies {
   implementation project(':printing')
   implementation project(':richtext-commonmark')
-  implementation project(':richtext-ui')
+  implementation project(':richtext-ui-material')
   implementation project(':slideshow')
   implementation deps.androidx.appcompat
   implementation deps.compose.activity

--- a/sample/src/main/java/com/zachklipp/richtext/sample/DocumentSample.kt
+++ b/sample/src/main/java/com/zachklipp/richtext/sample/DocumentSample.kt
@@ -40,7 +40,7 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontStyle.Italic
+import androidx.compose.ui.text.font.FontStyle.Companion.Italic
 import androidx.compose.ui.text.font.FontWeight.Companion.Bold
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration.Companion.Underline
@@ -55,6 +55,7 @@ import androidx.compose.ui.unit.sp
 import com.zachklipp.richtext.ui.FormattedList
 import com.zachklipp.richtext.ui.ListType.Unordered
 import com.zachklipp.richtext.ui.RichText
+import com.zachklipp.richtext.ui.material.ProvideMaterialThemingToRichText
 import com.zachklipp.richtext.ui.printing.Printable
 import com.zachklipp.richtext.ui.printing.PrintableController
 import com.zachklipp.richtext.ui.printing.hideWhenPrinting
@@ -196,7 +197,10 @@ private val LargeGap = 96.dp
           secondary = Color(0x20, 0x79, 0xc7)
         )
       ) {
-        content()
+        // Printable leaves the current composition while rendering the content inside a PDF
+        ProvideMaterialThemingToRichText {
+          content()
+        }
       }
     }
   }
@@ -240,7 +244,7 @@ private val LargeGap = 96.dp
   verticalArrangement: Arrangement.Vertical = Arrangement.Top,
   content: @Composable () -> Unit
 ) {
-  val uppercaseTitle = remember(title) { title.toUpperCase(Locale.US) }
+  val uppercaseTitle = remember(title) { title.uppercase(Locale.US) }
 
   Column(verticalArrangement = verticalArrangement) {
     Text(

--- a/sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
+++ b/sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
@@ -26,12 +26,16 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.zachklipp.richtext.markdown.Markdown
+import com.zachklipp.richtext.ui.RichText
 import com.zachklipp.richtext.ui.RichTextStyle
+import com.zachklipp.richtext.ui.material.ProvideMaterialThemingToRichText
 import com.zachklipp.richtext.ui.resolveDefaults
 
 @Preview
 @Composable private fun MarkdownSamplePreview() {
-  MarkdownSample()
+  ProvideMaterialThemingToRichText {
+    MarkdownSample()
+  }
 }
 
 @Composable fun MarkdownSample() {
@@ -69,14 +73,17 @@ import com.zachklipp.richtext.ui.resolveDefaults
 
         SelectionContainer {
           Column(Modifier.verticalScroll(rememberScrollState())) {
-            Markdown(
-              content = sampleMarkdown,
+            RichText(
               style = richTextStyle,
-              modifier = Modifier.padding(8.dp),
-              onLinkClicked = {
-                Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
-              }
-            )
+              modifier = Modifier.padding(8.dp)
+            ) {
+              Markdown(
+                content = sampleMarkdown,
+                onLinkClicked = {
+                  Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
+                }
+              )
+            }
           }
         }
       }

--- a/sample/src/main/java/com/zachklipp/richtext/sample/PagedSample.kt
+++ b/sample/src/main/java/com/zachklipp/richtext/sample/PagedSample.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.zachklipp.richtext.ui.material.ProvideMaterialThemingToRichText
 import com.zachklipp.richtext.ui.printing.Paged
 import com.zachklipp.richtext.ui.printing.Printable
 import com.zachklipp.richtext.ui.printing.isBeingPrinted
@@ -33,9 +34,12 @@ import com.zachklipp.richtext.ui.printing.rememberPrintableController
   val controller = rememberPrintableController()
   val state = remember { PagedScreenState() }
   Printable(controller, printBreakpoints = state.drawBreakpoints) {
-    PagedScreen(state, doPrint = {
-      controller.print("Document Sample")
-    })
+    // Printable leaves the current composition while rendering the content inside a PDF
+    ProvideMaterialThemingToRichText {
+      PagedScreen(state, doPrint = {
+        controller.print("Document Sample")
+      })
+    }
   }
 }
 

--- a/sample/src/main/java/com/zachklipp/richtext/sample/RichTextSample.kt
+++ b/sample/src/main/java/com/zachklipp/richtext/sample/RichTextSample.kt
@@ -26,11 +26,14 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.zachklipp.richtext.ui.RichTextStyle
+import com.zachklipp.richtext.ui.material.ProvideMaterialThemingToRichText
 import com.zachklipp.richtext.ui.resolveDefaults
 
 @Preview
 @Composable private fun RichTextSamplePreview() {
-  RichTextSample()
+  ProvideMaterialThemingToRichText {
+    RichTextSample()
+  }
 }
 
 @Composable fun RichTextSample() {

--- a/sample/src/main/java/com/zachklipp/richtext/sample/SampleActivity.kt
+++ b/sample/src/main/java/com/zachklipp/richtext/sample/SampleActivity.kt
@@ -3,21 +3,14 @@ package com.zachklipp.richtext.sample
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.material.ripple.ExperimentalRippleApi
-import androidx.compose.material.ripple.LocalRippleNativeRendering
 import androidx.compose.runtime.CompositionLocalProvider
 
 class MainActivity : AppCompatActivity() {
 
-  @OptIn(ExperimentalRippleApi::class)
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContent {
-      // There's a bug with the new RippleDrawable implementation introduced in beta07 that causes
-      // a crash in some of the samples. See https://issuetracker.google.com/issues/188569367.
-      CompositionLocalProvider(LocalRippleNativeRendering provides false) {
-        SampleLauncher()
-      }
+      SampleLauncher()
     }
   }
 }

--- a/sample/src/main/java/com/zachklipp/richtext/sample/SampleLauncher.kt
+++ b/sample/src/main/java/com/zachklipp/richtext/sample/SampleLauncher.kt
@@ -16,8 +16,6 @@ import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
-import androidx.compose.material.ripple.ExperimentalRippleApi
-import androidx.compose.material.ripple.LocalRippleNativeRendering
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
@@ -30,6 +28,7 @@ import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.zachklipp.richtext.ui.material.ProvideMaterialThemingToRichText
 
 private val Samples = listOf<Pair<String, @Composable () -> Unit>>(
   "RichText Demo" to @Composable { RichTextSample() },
@@ -47,12 +46,14 @@ private val Samples = listOf<Pair<String, @Composable () -> Unit>>(
 @Composable fun SampleLauncher() {
   var currentSampleIndex: Int? by remember { mutableStateOf(null) }
 
-  Crossfade(currentSampleIndex) { index ->
-    index?.let {
-      BackHandler(onBack = { currentSampleIndex = null })
-      Samples[it].second()
+  ProvideMaterialThemingToRichText {
+    Crossfade(currentSampleIndex) { index ->
+      index?.let {
+        BackHandler(onBack = { currentSampleIndex = null })
+        Samples[it].second()
+      }
+        ?: SamplesListScreen(onSampleClicked = { currentSampleIndex = it })
     }
-      ?: SamplesListScreen(onSampleClicked = { currentSampleIndex = it })
   }
 }
 

--- a/sample/src/main/java/com/zachklipp/richtext/sample/ScreenPreview.kt
+++ b/sample/src/main/java/com/zachklipp/richtext/sample/ScreenPreview.kt
@@ -8,7 +8,9 @@ import android.hardware.display.DisplayManager.DisplayListener
 import android.os.Handler
 import android.util.DisplayMetrics
 import android.view.View
+import android.view.ViewGroup
 import android.view.WindowManager
+import android.widget.FrameLayout
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.text.selection.DisableSelection
@@ -65,7 +67,7 @@ import androidx.compose.ui.unit.IntSize
     val context = LocalContext.current
     val previewView = remember {
       val previewContext = context.applicationContext
-      View(previewContext)
+      FrameLayout(previewContext)
     }
 
     DisableSelection {

--- a/sample/src/main/java/com/zachklipp/richtext/sample/TextDemo.kt
+++ b/sample/src/main/java/com/zachklipp/richtext/sample/TextDemo.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.StrokeCap.Round
+import androidx.compose.ui.graphics.StrokeCap.Companion.Round
 import androidx.compose.ui.graphics.drawscope.withTransform
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
@@ -204,7 +204,7 @@ val slowLoadingImage = InlineContent {
 @OptIn(ExperimentalStdlibApi::class)
 private fun Builder.appendPreviewSentence(
   format: Format,
-  text: String = format.javaClass.simpleName.decapitalize(Locale.US)
+  text: String = format.javaClass.simpleName.replaceFirstChar { it.lowercase(Locale.US) }
 ) {
   append("Here is some ")
   withFormat(format) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,7 @@ pluginManagement {
 
 include ':printing'
 include ':richtext-ui'
+include ':richtext-ui-material'
 include ':richtext-commonmark'
 include ':sample'
 include ':slideshow'

--- a/slideshow/src/main/java/com/zachklipp/richtext/ui/slideshow/SlideshowTheme.kt
+++ b/slideshow/src/main/java/com/zachklipp/richtext/ui/slideshow/SlideshowTheme.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign.Center
+import androidx.compose.ui.text.style.TextAlign.Companion.Center
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp

--- a/slideshow/src/main/java/com/zachklipp/richtext/ui/slideshow/TitleSlide.kt
+++ b/slideshow/src/main/java/com/zachklipp/richtext/ui/slideshow/TitleSlide.kt
@@ -9,7 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.style.TextAlign.Center
+import androidx.compose.ui.text.style.TextAlign.Companion.Center
 import androidx.compose.ui.tooling.preview.Preview
 
 /**


### PR DESCRIPTION
- Add LocalRichTextLocals to replace LocalTextStyle and LocalContentColor
- Keep the spirit of LocalTextStyle and LocalContentColor but make them assignable by API
- Add a simple richtext-ui-material module for Material adopter users.
- Change Markdown to be an extension on RichTextScope to not repeat RichText API arguments.

Update versions
- Compose: 1.0.0-beta09
- Kotlin: 1.5.10
- AGP: 7.1.0-alpha02

- Change dummy View to FrameLayout in ScreenPreview because Compose is looking for a ViewGroup.