### PR TITLE
Compose stable release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
   ext.versions = [
-      targetSdk: 29,
-      compose: '1.0.0-beta07',
-      kotlin: '1.4.32',
-      commonmark: '0.15.2'
+      targetSdk: 30,
+      compose: '1.0.0',
+      kotlin: '1.5.10',
+      commonmark: '0.18.0'
   ]
 
   rootProject.ext.defaultAndroidConfig = {
@@ -32,7 +32,7 @@ buildscript {
   }
 
   ext.deps = [
-      android_gradle_plugin: "com.android.tools.build:gradle:7.1.0-alpha01",
+      android_gradle_plugin: "com.android.tools.build:gradle:7.0.0",
 
       androidx: [
           activity: "androidx.activity:activity:1.1.0",
@@ -51,7 +51,7 @@ buildscript {
           viewbinding: "androidx.databinding:viewbinding:3.6.1",
       ],
       compose: [
-          activity: "androidx.activity:activity-compose:1.3.0-alpha08",
+          activity: "androidx.activity:activity-compose:1.3.0",
           foundation: "androidx.compose.foundation:foundation:${versions.compose}",
           layout: "androidx.compose.foundation:foundation-layout:${versions.compose}",
           material: "androidx.compose.material:material:${versions.compose}",
@@ -73,11 +73,11 @@ buildscript {
           ]
       ],
       commonmark: [
-          core: "com.atlassian.commonmark:commonmark:${versions.commonmark}",
-          tables: "com.atlassian.commonmark:commonmark-ext-gfm-tables:${versions.commonmark}",
-          strikethrough: "com.atlassian.commonmark:commonmark-ext-gfm-strikethrough:${versions.commonmark}"
+          core: "org.commonmark:commonmark:${versions.commonmark}",
+          tables: "org.commonmark:commonmark-ext-gfm-tables:${versions.commonmark}",
+          strikethrough: "org.commonmark:commonmark-ext-gfm-strikethrough:${versions.commonmark}"
       ],
-      accompanist: "com.google.accompanist:accompanist-coil:0.10.0",
+      coil: "io.coil-kt:coil-compose:1.3.1",
       mavenPublish: "com.vanniktech:gradle-maven-publish-plugin:0.13.0",
       ktlint: "org.jlleitschuh.gradle:ktlint-gradle:10.0.0",
   ]
@@ -86,7 +86,6 @@ buildscript {
     mavenCentral()
     gradlePluginPortal()
     google()
-    jcenter()
   }
 
   dependencies {
@@ -104,8 +103,8 @@ plugins {
 }
 
 repositories {
-  // For Dokka
-  jcenter()
+  // For Dokka, see https://github.com/Kotlin/dokka/releases/tag/v1.4.32
+  maven { url = "https://maven.pkg.jetbrains.space/public/p/kotlinx-html/maven" }
 }
 
 // See https://stackoverflow.com/questions/25324880/detect-ide-environment-with-gradle
@@ -117,7 +116,6 @@ subprojects {
   repositories {
     google()
     mavenCentral()
-    jcenter()
   }
 
   tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,19 +21,19 @@ kotlin.code.style=official
 # Required to publish to Nexus (see https://github.com/gradle/gradle/issues/11308)
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 
-GROUP=com.zachklipp.compose-richtext
+GROUP=com.halilibo.compose-richtext
 VERSION_NAME=0.4.0-SNAPSHOT
 
 POM_DESCRIPTION=A collection of Compose libraries for advanced text formatting and alternative display types.
 
-POM_URL=https://github.com/zach-klippenstein/compose-richtext/
-POM_SCM_URL=https://github.com/zach-klippenstein/compose-richtext/
-POM_SCM_CONNECTION=scm:git:git://github.com/zach-klippenstein/compose-richtext.git
-POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/zach-klippenstein/compose-richtext.git
+POM_URL=https://github.com/halilozercan/compose-richtext/
+POM_SCM_URL=https://github.com/halilozercan/compose-richtext/
+POM_SCM_CONNECTION=scm:git:git://github.com/halilozercan/compose-richtext.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/halilozercan/compose-richtext.git
 
 POM_LICENCE_NAME=The Apache Software License, Version 2.0
 POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
 POM_LICENCE_DIST=repo
 
-POM_DEVELOPER_ID=zach-klippenstein
-POM_DEVELOPER_NAME=Zach Klippenstein
+POM_DEVELOPER_ID=halilozercan
+POM_DEVELOPER_NAME=Halil Ozercan

--- a/printing/src/main/java/com/zachklipp/richtext/ui/printing/Paged.kt
+++ b/printing/src/main/java/com/zachklipp/richtext/ui/printing/Paged.kt
@@ -370,7 +370,7 @@ private fun DrawScope.drawBreakpoints(
     val childConstraints = constraints.copy(maxHeight = Int.MAX_VALUE)
     val placeables = measurables.map { it.measure(childConstraints) }
     val maxChildWidth = placeables.maxOfOrNull { it.width } ?: 0
-    val totalChildHeight = placeables.sumBy { it.height }
+    val totalChildHeight = placeables.sumOf { it.height }
 
     val actualWidth = constraints.constrainWidth(maxChildWidth)
     val actualHeight = constraints.constrainHeight(totalChildHeight)

--- a/printing/src/main/java/com/zachklipp/richtext/ui/printing/PrinterMetrics.kt
+++ b/printing/src/main/java/com/zachklipp/richtext/ui/printing/PrinterMetrics.kt
@@ -13,7 +13,8 @@ private const val DP_DPI = 160
 public const val DefaultPageDpi: Int = 100
 
 /** Represents a PostScript point (1/72 of an inch). */
-internal inline class Pts(val value: Int) {
+@JvmInline
+internal value class Pts(val value: Int) {
   override fun toString(): String = "$value.pts"
 }
 

--- a/richtext-commonmark/build.gradle
+++ b/richtext-commonmark/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 
   api project(":richtext-ui")
 
-  implementation deps.accompanist
+  implementation deps.coil
   implementation deps.commonmark.core
   implementation deps.commonmark.strikethrough
   implementation deps.commonmark.tables

--- a/richtext-commonmark/src/main/java/com/zachklipp/richtext/markdown/BlockRender.kt
+++ b/richtext-commonmark/src/main/java/com/zachklipp/richtext/markdown/BlockRender.kt
@@ -10,7 +10,7 @@ import com.zachklipp.richtext.ui.RichTextScope
 import com.zachklipp.richtext.ui.Table
 
 @Composable
-internal fun RichTextScope.renderTable(node: AstTableRoot) {
+internal fun RichTextScope.RenderTable(node: AstTableRoot) {
   Table(
     headerRow = {
       node.filterChildrenIsInstance<AstTableHeader>()

--- a/richtext-commonmark/src/main/java/com/zachklipp/richtext/markdown/Markdown.kt
+++ b/richtext-commonmark/src/main/java/com/zachklipp/richtext/markdown/Markdown.kt
@@ -159,7 +159,7 @@ internal fun RichTextScope.RecursiveRenderMarkdownAst(astNode: AstNode?) {
       Text(astNode.literal)
     }
     is AstTableRoot -> {
-      renderTable(astNode)
+      RenderTable(astNode)
     }
     else -> visitChildren(astNode)
   }

--- a/richtext-commonmark/src/main/java/com/zachklipp/richtext/markdown/MarkdownRichText.kt
+++ b/richtext-commonmark/src/main/java/com/zachklipp/richtext/markdown/MarkdownRichText.kt
@@ -4,9 +4,11 @@ import androidx.compose.foundation.Image
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import com.google.accompanist.coil.rememberCoilPainter
-import com.google.accompanist.imageloading.ImageLoadState.Error
-import com.google.accompanist.imageloading.ImageLoadState.Loading
+import coil.annotation.ExperimentalCoilApi
+import coil.compose.ImagePainter.State.Error
+import coil.compose.ImagePainter.State.Loading
+import coil.compose.ImagePainter.State.Success
+import coil.compose.rememberImagePainter
 import com.zachklipp.richtext.markdown.extensions.AstStrikethrough
 import com.zachklipp.richtext.ui.BlockQuote
 import com.zachklipp.richtext.ui.FormattedList
@@ -52,6 +54,7 @@ internal fun RichTextScope.MarkdownRichText(astNode: AstNode) {
   InlineRichText(text = richText)
 }
 
+@OptIn(ExperimentalCoilApi::class)
 private fun computeRichTextString(
   astNode: AstNode,
   onLinkClicked: (String) -> Unit
@@ -86,11 +89,11 @@ private fun computeRichTextString(
         )
         is AstImage -> {
           richTextStringBuilder.appendInlineContent(content = InlineContent {
-            val painter = rememberCoilPainter(request = currentNode.destination)
-            Image(painter = painter, contentDescription = currentNode.title)
-            when (painter.loadState) {
+            val painter = rememberImagePainter(data = currentNode.destination)
+            when (painter.state) {
               is Loading -> Text("Loading Image...")
               is Error -> Text("Image failed to load")
+              is Success -> Image(painter = painter, contentDescription = currentNode.title)
             }
           })
           null

--- a/richtext-ui/api/richtext-ui.api
+++ b/richtext-ui/api/richtext-ui.api
@@ -249,15 +249,14 @@ public final class com/zachklipp/richtext/ui/string/ComposableSingletons$TextKt 
 
 public final class com/zachklipp/richtext/ui/string/InlineContent {
 	public static final field $stable I
-	public fun <init> (Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/text/PlaceholderVerticalAlign;Lkotlin/jvm/functions/Function4;)V
-	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/text/PlaceholderVerticalAlign;Lkotlin/jvm/functions/Function4;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;ILkotlin/jvm/functions/Function4;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;ILkotlin/jvm/functions/Function4;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/zachklipp/richtext/ui/string/RichTextString {
 	public final fun copy (Landroidx/compose/ui/text/AnnotatedString;Ljava/util/Map;)Lcom/zachklipp/richtext/ui/string/RichTextString;
 	public static synthetic fun copy$default (Lcom/zachklipp/richtext/ui/string/RichTextString;Landroidx/compose/ui/text/AnnotatedString;Ljava/util/Map;ILjava/lang/Object;)Lcom/zachklipp/richtext/ui/string/RichTextString;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getLength ()I
 	public final fun getText ()Ljava/lang/String;
 	public fun hashCode ()I
 	public final fun plus (Lcom/zachklipp/richtext/ui/string/RichTextString;)Lcom/zachklipp/richtext/ui/string/RichTextString;
@@ -284,6 +283,7 @@ public final class com/zachklipp/richtext/ui/string/RichTextString$Builder {
 public abstract class com/zachklipp/richtext/ui/string/RichTextString$Format {
 	public static final field $stable I
 	public static final field Companion Lcom/zachklipp/richtext/ui/string/RichTextString$Format$Companion;
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/CodeBlock.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/CodeBlock.kt
@@ -5,7 +5,6 @@ package com.zachklipp.richtext.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.LocalContentColor
 import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.ProvideTextStyle

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/FormattedList.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/FormattedList.kt
@@ -156,13 +156,13 @@ internal fun ListStyle.resolveDefaults(): ListStyle = ListStyle(
   unorderedMarkers = unorderedMarkers ?: DefaultUnorderedMarkers
 )
 
-private val ListLevelAmbient = compositionLocalOf { 0 }
+private val LocalListLevel = compositionLocalOf { 0 }
 
 /**
- * Composes [children] with their [ListLevelAmbient] reset back to 0.
+ * Composes [children] with their [LocalListLevel] reset back to 0.
  */
 @Composable internal fun RestartListLevel(children: @Composable () -> Unit) {
-  CompositionLocalProvider(ListLevelAmbient provides 0) {
+  CompositionLocalProvider(LocalListLevel provides 0) {
     children()
   }
 }
@@ -195,7 +195,7 @@ private val ListLevelAmbient = compositionLocalOf { 0 }
   val density = LocalDensity.current
   val markerIndent = with(density) { listStyle.markerIndent!!.toDp() }
   val contentsIndent = with(density) { listStyle.contentsIndent!!.toDp() }
-  val currentLevel = ListLevelAmbient.current
+  val currentLevel = LocalListLevel.current
 
   PrefixListLayout(
     count = items.size,
@@ -208,7 +208,7 @@ private val ListLevelAmbient = compositionLocalOf { 0 }
     },
     itemForIndex = { index ->
       RichText {
-        CompositionLocalProvider(ListLevelAmbient provides currentLevel + 1) {
+        CompositionLocalProvider(LocalListLevel provides currentLevel + 1) {
           drawItem(items[index])
         }
       }
@@ -264,7 +264,7 @@ private val ListLevelAmbient = compositionLocalOf { 0 }
     val widestItem = itemPlaceables.maxByOrNull { it.width }!!
 
     val listWidth = widestPrefix.width + widestItem.width
-    val listHeight = itemPlaceables.sumBy { it.height }
+    val listHeight = itemPlaceables.sumOf { it.height }
     layout(listWidth, listHeight) {
       var y = 0
 

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/Heading.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/Heading.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontStyle.Italic
+import androidx.compose.ui.text.font.FontStyle.Companion.Italic
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.resolveDefaults
 import androidx.compose.ui.tooling.preview.Preview

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/SimpleTableLayout.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/SimpleTableLayout.kt
@@ -71,7 +71,7 @@ internal fun SimpleTableLayout(
     val rowHeights = rowPlaceables.map { row -> row.maxByOrNull { it.height }!!.height }
 
     val tableWidth = constraints.maxWidth
-    val tableHeight = (rowHeights.sumBy { it } + cellSpacingHeight).roundToInt()
+    val tableHeight = (rowHeights.sumOf { it } + cellSpacingHeight).roundToInt()
     layout(tableWidth, tableHeight) {
       var y = cellSpacing
       val rowOffsets = mutableListOf<Float>()

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/string/InlineContent.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/string/InlineContent.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
-import androidx.compose.ui.text.PlaceholderVerticalAlign.AboveBaseline
+import androidx.compose.ui.text.PlaceholderVerticalAlign.Companion.AboveBaseline
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/string/RichTextString.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/string/RichTextString.kt
@@ -98,7 +98,7 @@ public data class RichTextString internal constructor(
   internal val formatObjects: Map<String, Any>
 ) {
 
-  val length: Int get() = taggedString.length
+  private val length: Int get() = taggedString.length
   val text: String get() = taggedString.text
 
   public operator fun plus(other: RichTextString): RichTextString =

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
 
     <activity
         android:name=".MainActivity"
-        android:configChanges="orientation|screenSize|smallestScreenSize|fontScale|density|layoutDirection">
+        android:configChanges="orientation|screenSize|smallestScreenSize|fontScale|density|layoutDirection"
+        android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />

--- a/sample/src/main/java/com/zachklipp/richtext/sample/DocumentSample.kt
+++ b/sample/src/main/java/com/zachklipp/richtext/sample/DocumentSample.kt
@@ -40,7 +40,7 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontStyle.Italic
+import androidx.compose.ui.text.font.FontStyle.Companion.Italic
 import androidx.compose.ui.text.font.FontWeight.Companion.Bold
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration.Companion.Underline
@@ -240,7 +240,7 @@ private val LargeGap = 96.dp
   verticalArrangement: Arrangement.Vertical = Arrangement.Top,
   content: @Composable () -> Unit
 ) {
-  val uppercaseTitle = remember(title) { title.toUpperCase(Locale.US) }
+  val uppercaseTitle = remember(title) { title.uppercase(Locale.US) }
 
   Column(verticalArrangement = verticalArrangement) {
     Text(

--- a/sample/src/main/java/com/zachklipp/richtext/sample/SampleActivity.kt
+++ b/sample/src/main/java/com/zachklipp/richtext/sample/SampleActivity.kt
@@ -3,21 +3,13 @@ package com.zachklipp.richtext.sample
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.material.ripple.ExperimentalRippleApi
-import androidx.compose.material.ripple.LocalRippleNativeRendering
-import androidx.compose.runtime.CompositionLocalProvider
 
 class MainActivity : AppCompatActivity() {
 
-  @OptIn(ExperimentalRippleApi::class)
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContent {
-      // There's a bug with the new RippleDrawable implementation introduced in beta07 that causes
-      // a crash in some of the samples. See https://issuetracker.google.com/issues/188569367.
-      CompositionLocalProvider(LocalRippleNativeRendering provides false) {
-        SampleLauncher()
-      }
+      SampleLauncher()
     }
   }
 }

--- a/sample/src/main/java/com/zachklipp/richtext/sample/SampleLauncher.kt
+++ b/sample/src/main/java/com/zachklipp/richtext/sample/SampleLauncher.kt
@@ -16,10 +16,7 @@ import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
-import androidx.compose.material.ripple.ExperimentalRippleApi
-import androidx.compose.material.ripple.LocalRippleNativeRendering
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember

--- a/sample/src/main/java/com/zachklipp/richtext/sample/ScreenPreview.kt
+++ b/sample/src/main/java/com/zachklipp/richtext/sample/ScreenPreview.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.zachklipp.richtext.sample
 
 import android.content.Context
@@ -6,9 +8,10 @@ import android.content.Context.WINDOW_SERVICE
 import android.hardware.display.DisplayManager
 import android.hardware.display.DisplayManager.DisplayListener
 import android.os.Handler
+import android.os.Looper
 import android.util.DisplayMetrics
-import android.view.View
 import android.view.WindowManager
+import android.widget.FrameLayout
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.text.selection.DisableSelection
@@ -65,7 +68,7 @@ import androidx.compose.ui.unit.IntSize
     val context = LocalContext.current
     val previewView = remember {
       val previewContext = context.applicationContext
-      View(previewContext)
+      FrameLayout(previewContext)
     }
 
     DisableSelection {
@@ -106,7 +109,7 @@ private class DisplaySizeCalculator(context: Context) : RememberObserver,
 
   override fun onRemembered() {
     // Update the preview on device rotation, for example.
-    displayManager.registerDisplayListener(this, Handler())
+    displayManager.registerDisplayListener(this, Handler(Looper.getMainLooper()))
   }
 
   override fun onForgotten() {

--- a/sample/src/main/java/com/zachklipp/richtext/sample/TextDemo.kt
+++ b/sample/src/main/java/com/zachklipp/richtext/sample/TextDemo.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.StrokeCap.Round
+import androidx.compose.ui.graphics.StrokeCap.Companion.Round
 import androidx.compose.ui.graphics.drawscope.withTransform
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
@@ -50,7 +50,6 @@ import com.zachklipp.richtext.ui.string.richTextString
 import com.zachklipp.richtext.ui.string.withFormat
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import java.util.Locale
 
 @Preview(showBackground = true)
 @Composable fun TextPreview() {
@@ -204,7 +203,7 @@ val slowLoadingImage = InlineContent {
 @OptIn(ExperimentalStdlibApi::class)
 private fun Builder.appendPreviewSentence(
   format: Format,
-  text: String = format.javaClass.simpleName.decapitalize(Locale.US)
+  text: String = format.javaClass.simpleName.replaceFirstChar { it.lowercase() }
 ) {
   append("Here is some ")
   withFormat(format) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
   repositories {
     gradlePluginPortal()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/slideshow/api/slideshow.api
+++ b/slideshow/api/slideshow.api
@@ -88,7 +88,7 @@ public final class com/zachklipp/richtext/ui/slideshow/SlideshowTheme {
 }
 
 public final class com/zachklipp/richtext/ui/slideshow/SlideshowThemeKt {
-	public static final fun getSlideshowThemeAmbient ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+	public static final fun getLocalSlideshowTheme ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 }
 
 public final class com/zachklipp/richtext/ui/slideshow/TitleSlideKt {

--- a/slideshow/src/main/java/com/zachklipp/richtext/ui/slideshow/BodySlide.kt
+++ b/slideshow/src/main/java/com/zachklipp/richtext/ui/slideshow/BodySlide.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.tooling.preview.Preview
   body: @Composable () -> Unit,
   footer: @Composable () -> Unit = { SlideNumberFooter() }
 ) {
-  val theme = SlideshowThemeAmbient.current
+  val theme = LocalSlideshowTheme.current
   Column(
     Modifier
       .fillMaxSize()
@@ -49,7 +49,7 @@ import androidx.compose.ui.tooling.preview.Preview
  * A simple horizontal divider line which uses the [SlideshowTheme] content color.
  */
 @Composable public fun SlideScope.SlideDivider() {
-  Divider(color = SlideshowThemeAmbient.current.contentColor)
+  Divider(color = LocalSlideshowTheme.current.contentColor)
 }
 
 /**

--- a/slideshow/src/main/java/com/zachklipp/richtext/ui/slideshow/Slideshow.kt
+++ b/slideshow/src/main/java/com/zachklipp/richtext/ui/slideshow/Slideshow.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.zachklipp.richtext.ui.slideshow
 
 import android.app.Activity
@@ -127,7 +129,7 @@ public class SlideshowController {
   ) {
     CompositionLocalProvider(
       LocalContentColor provides theme.contentColor,
-      SlideshowThemeAmbient provides theme,
+      LocalSlideshowTheme provides theme,
     ) {
       ProvideTextStyle(theme.baseTextStyle) {
         // This crossfade provides transitions between slides.
@@ -182,7 +184,7 @@ public class SlideshowController {
   var scrubberSlide by remember(controller.currentSlide) {
     mutableStateOf(controller.currentSlide.toFloat())
   }
-  val theme = SlideshowThemeAmbient.current
+  val theme = LocalSlideshowTheme.current
 
   BoxWithConstraints(Modifier.fillMaxWidth()) {
     val outerconstraints = constraints
@@ -279,6 +281,7 @@ private fun Modifier.splitClickable(
   )
 }
 
+@Suppress("Deprecated")
 private fun DisposableEffectScope.configureFullScreenWindow(view: View): DisposableEffectResult {
   tailrec fun Context.findActivity(): Activity? = when (this) {
     is Activity -> this

--- a/slideshow/src/main/java/com/zachklipp/richtext/ui/slideshow/SlideshowTheme.kt
+++ b/slideshow/src/main/java/com/zachklipp/richtext/ui/slideshow/SlideshowTheme.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign.Center
+import androidx.compose.ui.text.style.TextAlign.Companion.Center
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -45,5 +45,5 @@ public data class SlideshowTheme(
   val aspectRatio: Float = 16 / 9f
 )
 
-public val SlideshowThemeAmbient: ProvidableCompositionLocal<SlideshowTheme> =
+public val LocalSlideshowTheme: ProvidableCompositionLocal<SlideshowTheme> =
   staticCompositionLocalOf { SlideshowTheme() }

--- a/slideshow/src/main/java/com/zachklipp/richtext/ui/slideshow/TitleSlide.kt
+++ b/slideshow/src/main/java/com/zachklipp/richtext/ui/slideshow/TitleSlide.kt
@@ -7,9 +7,8 @@ import androidx.compose.material.ProvideTextStyle
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.style.TextAlign.Center
+import androidx.compose.ui.text.style.TextAlign.Companion.Center
 import androidx.compose.ui.tooling.preview.Preview
 
 /**
@@ -20,7 +19,7 @@ import androidx.compose.ui.tooling.preview.Preview
   title: @Composable () -> Unit,
   subtitle: (@Composable () -> Unit)? = null
 ) {
-  val theme = SlideshowThemeAmbient.current
+  val theme = LocalSlideshowTheme.current
   Column(horizontalAlignment = CenterHorizontally) {
     ProvideTextStyle(TextStyle(textAlign = Center)) {
       ProvideTextStyle(theme.titleStyle, content = title)


### PR DESCRIPTION
This commit bumps several versions
- Compose: 1.0.0
- Kotlin: 1.5.10
- AGP: 7.0.0, not really a bump but switched to stable version
- several others e.g. Coil, Commonmark, Activity, etc.

Build SDK version is also bumped to 30. However, this introduces some deprecations that we might want to refactor in the future. For now, deprecation errors are suppressed. 

Some old Ambient namings are changed to _Local_