### PR TITLE
Docs migration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: zach-klippenstein
+github: halilozercan
 # patreon: # Replace with a single Patreon username
 # open_collective: # Replace with a single Open Collective username
 # ko_fi: # Replace with a single Ko-fi username

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,5 +22,5 @@ jobs:
           python-version: 3.x
       - run: pip install mkdocs-material
       - run: ./gradlew dokkaGfmCollector
-      - run: mv build/dokka/gfmCollector/compose-richtext docs/api
+      - run: mv build/dokka/gfmCollector/ docs/api
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,8 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material
-      - run: ./gradlew dokkaGfmCollector
-      - run: mv build/dokka/gfmCollector/ docs/api
+      - name: Install dependencies
+        run: pip install mkdocs-material
+      - name: Generate docs
+        run: ./gen_docs.sh
       - run: mkdocs gh-deploy --force

--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,11 @@ repositories {
   mavenCentral()
 }
 
+tasks.withType(org.jetbrains.dokka.gradle.DokkaMultiModuleTask).configureEach {
+  outputDirectory = rootProject.file('docs/api')
+  failOnWarning = true
+}
+
 // See https://stackoverflow.com/questions/25324880/detect-ide-environment-with-gradle
 def isRunningFromIde() {
   return project.properties["android.injected.invoked.from.ide"] == "true"
@@ -136,6 +141,34 @@ subprojects {
 
       if (project.name != "sample" && !name.contains("test")) {
         freeCompilerArgs += "-Xexplicit-api=strict"
+      }
+    }
+  }
+
+  // taken from https://github.com/google/accompanist/blob/main/build.gradle
+  afterEvaluate {
+    if (tasks.findByName('dokkaHtmlPartial') == null) {
+      // If dokka isn't enabled on this module, skip
+      return
+    }
+
+    tasks.named('dokkaHtmlPartial') {
+      dokkaSourceSets.configureEach {
+        reportUndocumented.set(true)
+        skipEmptyPackages.set(true)
+        skipDeprecated.set(true)
+        jdkVersion.set(11)
+
+        // Add Android SDK packages
+        noAndroidSdkLink.set(false)
+
+        sourceLink {
+          localDirectory.set(project.file("src/main/java"))
+          // URL showing where the source code can be accessed through the web browser
+          remoteUrl.set(new URL("https://github.com/halilozercan/compose-richtext/blob/main/${project.name}/src/main/java"))
+          // Suffix which is used to append the line number to the URL. Use #L for GitHub
+          remoteLineSuffix.set("#L")
+        }
       }
     }
   }

--- a/docs/printing.md
+++ b/docs/printing.md
@@ -15,10 +15,10 @@ dependencies {
 There are multiple entry points into this library. See their kdoc for usage and parameter
 documentation, and take a look at the samples for example code.
 
-### [`Printable`](/api/com.zachklipp.richtext.ui.printing/-printable/)
+### [`Printable`](../api/printing/com.zachklipp.richtext.ui.printing/-printable.html)
 
 This is the simplest entry point. It's a composable function that displays its children on screen,
-but can also print itself. Printing is triggered by the [`PrintableController`](/api/com.zachklipp.richtext.ui.printing/-printable-controller/)
+but can also print itself. Printing is triggered by the [`PrintableController`](../api/printing/com.zachklipp.richtext.ui.printing/-printable-controller/index.html)
 passed to `Printable`. `PrintableController` is a hoisted state type, just like `ScrollState`,
 created by calling `rememberPrintableController`.
 
@@ -33,7 +33,7 @@ Printable(printController) {
 }
 ```
 
-### [`ComposePrintAdapter`](/api/com.zachklipp.richtext.ui.printing/-compose-print-adapter/-compose-print-adapter/)
+### [`ComposePrintAdapter`](../api/printing/com.zachklipp.richtext.ui.printing/-compose-print-adapter/-compose-print-adapter.html)
 
 This is a [`PrintDocumentAdapter`](https://developer.android.com/reference/android/print/PrintDocumentAdapter)
 that can be used directly with Android's printing APIs to print any composable function. It takes,
@@ -41,7 +41,7 @@ at minimum, the `ComponentActivity` that owns the print adapter (as required by 
 framework), a string name for the document, and the composable function that defines the content to
 print. See the linked API documentation for more details.
 
-### [`Paged`](/api/com.zachklipp.richtext.ui.printing/-paged/)
+### [`Paged`](../api/printing/com.zachklipp.richtext.ui.printing/-paged.html)
 
 This is another composable, but doesn't actually have anything to do with printing.
 Conceptually it's similar to a `ScrollableColumn` – it lays its contents out at full height, then
@@ -50,12 +50,12 @@ are clipped at the bottom, by measuring where all the leaf composables (those wi
 children) are located clipping the content before them. It is used by the printing APIs to try to
 ensure that composable content looks decent when split into printer pages.
 
-See the [`PagedSample`](https://github.com/zach-klippenstein/compose-richtext/blob/main/sample/src/main/java/com/zachklipp/richtext/sample/PagedSample.kt)
+See the [`PagedSample`](https://github.com/halilozercan/compose-richtext/blob/main/sample/src/main/java/com/zachklipp/richtext/sample/PagedSample.kt)
 for more information.
 
 ## Demo
 
-The [`DocumentSample`](https://github.com/zach-klippenstein/compose-richtext/blob/main/sample/src/main/java/com/zachklipp/richtext/sample/DocumentSample.kt)
+The [`DocumentSample`](https://github.com/halilozercan/compose-richtext/blob/main/sample/src/main/java/com/zachklipp/richtext/sample/DocumentSample.kt)
 tries to match the style of one of the Google Docs templates. It looks great
 on small phone screens, but also prints:
 

--- a/docs/richtext-commonmark.md
+++ b/docs/richtext-commonmark.md
@@ -13,7 +13,7 @@ dependencies {
 
 ## Usage
 
-The simplest way to render markdown is just pass a string to the [`Markdown`](/api/com.zachklipp.richtext.markdown/-markdown/)
+The simplest way to render markdown is just pass a string to the [`Markdown`](../api/richtext-commonmark/com.zachklipp.richtext.markdown/-markdown.html)
 composable:
 
 ~~~kotlin

--- a/gen_docs.sh
+++ b/gen_docs.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Copyright 2021 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Fail on any error
+set -ex
+
+DOCS_ROOT=docs-gen
+
+[ -d $DOCS_ROOT ] && rm -r $DOCS_ROOT
+mkdir $DOCS_ROOT
+
+# Clear out the old API docs
+[ -d docs/api ] && rm -r docs/api
+# Build the docs with dokka
+./gradlew dokkaHtmlMultiModule --stacktrace
+
+# Create a copy of our docs at our $DOCS_ROOT
+cp -a docs/* $DOCS_ROOT
+
+# Convert docs/xxx.md links to just xxx/
+sed -i.bak 's/docs\/\([a-zA-Z-]*\).md/\1/' $DOCS_ROOT/index.md
+
+# Finally delete all of the backup files
+find . -name '*.bak' -delete

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,8 @@ site_url: https://halilibo.com/compose-richtext
 remote_branch: gh-pages
 edit_uri: edit/main/docs/
 
+docs_dir: docs-gen
+
 theme:
   name: material
   icon:
@@ -27,5 +29,5 @@ nav:
   - richtext-commonmark.md
   - printing.md
   - slideshow.md
-  - 'API Reference': api/index.md
+  - 'API Reference': api/
   - Changelog: https://github.com/halilozercan/compose-richtext/releases

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/FormattedList.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/FormattedList.kt
@@ -173,7 +173,7 @@ private val LocalListLevel = compositionLocalOf { 0 }
  * @sample com.zachklipp.richtext.ui.OrderedListPreview
  * @sample com.zachklipp.richtext.ui.UnorderedListPreview
  */
-// inline is required for https://github.com/zach-klippenstein/compose-richtext/issues/7
+// inline is required for https://github.com/halilozercan/compose-richtext/issues/7
 @Suppress("NOTHING_TO_INLINE")
 @Composable public inline fun RichTextScope.FormattedList(
   listType: ListType,

--- a/sample/src/main/java/com/zachklipp/richtext/sample/DocumentSample.kt
+++ b/sample/src/main/java/com/zachklipp/richtext/sample/DocumentSample.kt
@@ -156,7 +156,7 @@ private val LargeGap = 96.dp
         }
       )
 
-      val sourceUrl = "https://github.com/zach-klippenstein/compose-richtext"
+      val sourceUrl = "https://github.com/halilozercan/compose-richtext"
       Footer(
         if (isBeingPrinted) {
           "This document was built and printed with Compose. It is also available as an app."


### PR DESCRIPTION
This PR finishes the migration for docs site.

- Start using the same mkdocs+dokka setup as Accompanist.
- Remove zach-klipp references to the old repository from docs and code.