### PR TITLE
Refactor Text composable that takes RichTextString

### DIFF
--- a/richtext-ui/api/richtext-ui.api
+++ b/richtext-ui/api/richtext-ui.api
@@ -376,6 +376,6 @@ public final class com/zachklipp/richtext/ui/string/RichTextStringStyle$Companio
 }
 
 public final class com/zachklipp/richtext/ui/string/TextKt {
-	public static final fun Text (Lcom/zachklipp/richtext/ui/RichTextScope;Lcom/zachklipp/richtext/ui/string/RichTextString;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun Text-7zs97cc (Lcom/zachklipp/richtext/ui/RichTextScope;Lcom/zachklipp/richtext/ui/string/RichTextString;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;ZIILandroidx/compose/runtime/Composer;II)V
 }
 

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/RichTextLocals.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/RichTextLocals.kt
@@ -1,16 +1,21 @@
 package com.zachklipp.richtext.ui
 
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
+import com.zachklipp.richtext.ui.string.RichTextString
 
 /**
  * Carries the text style in Composition tree. [Heading], [CodeBlock],
@@ -44,16 +49,6 @@ internal val RichTextScope.currentContentColor: Color
 
 /**
  * Intended for preview composables.
- *
- * Instead of
- * ```
- * BasicText("...", style = currentTextStyle)
- * ```
- *
- * We can write as follows
- * ```
- * InternalBasicText("...")
- * ```
  */
 @Composable
 internal fun RichTextScope.Text(
@@ -99,6 +94,45 @@ internal fun RichTextScope.Text(
     overflow = overflow,
     softWrap = softWrap,
     maxLines = maxLines,
+    inlineContent = inlineContent
+  )
+}
+
+/**
+ * Default ClickableText implementation from Compose does not take inlineContent for some reason.
+ * Instead of replicating the same behavior inside [Text] that takes [RichTextString], we separate
+ * the logic into our own [ClickableText].
+ */
+@Composable
+internal fun RichTextScope.ClickableText(
+  text: AnnotatedString,
+  modifier: Modifier = Modifier,
+  softWrap: Boolean = true,
+  overflow: TextOverflow = TextOverflow.Clip,
+  maxLines: Int = Int.MAX_VALUE,
+  onTextLayout: (TextLayoutResult) -> Unit = {},
+  inlineContent: Map<String, InlineTextContent> = mapOf(),
+  onClick: (Int) -> Unit
+) {
+  val layoutResult = remember { mutableStateOf<TextLayoutResult?>(null) }
+  val pressIndicator = Modifier.pointerInput(onClick) {
+    detectTapGestures { pos ->
+      layoutResult.value?.let { layoutResult ->
+        onClick(layoutResult.getOffsetForPosition(pos))
+      }
+    }
+  }
+
+  Text(
+    text = text,
+    modifier = modifier.then(pressIndicator),
+    softWrap = softWrap,
+    overflow = overflow,
+    maxLines = maxLines,
+    onTextLayout = {
+      layoutResult.value = it
+      onTextLayout(it)
+    },
     inlineContent = inlineContent
   )
 }

--- a/richtext-ui/src/main/java/com/zachklipp/richtext/ui/string/Text.kt
+++ b/richtext-ui/src/main/java/com/zachklipp/richtext/ui/string/Text.kt
@@ -1,51 +1,27 @@
 package com.zachklipp.richtext.ui.string
 
-import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.Layout
-import androidx.compose.ui.node.Ref
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextLayoutResult
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Constraints
-import com.zachklipp.richtext.ui.RichTextScope
-import com.zachklipp.richtext.ui.Text
-import com.zachklipp.richtext.ui.currentContentColor
-import com.zachklipp.richtext.ui.currentRichTextStyle
+import androidx.compose.ui.text.style.TextOverflow
+import com.zachklipp.richtext.ui.*
 import com.zachklipp.richtext.ui.string.RichTextString.Format
-import com.zachklipp.richtext.ui.string.RichTextString.Format.Bold
 import com.zachklipp.richtext.ui.string.RichTextString.Format.Link
-
-private const val ZERO_WIDTH_CHAR = "\u200B"
-
-@Preview(showBackground = true)
-@Composable private fun TextPreview() {
-  RichTextScope.Text(richTextString {
-    append("I'm ")
-    withFormat(Bold) {
-      append("bold!")
-    }
-  })
-}
 
 /**
  * Renders a [RichTextString] as created with [richTextString].
  *
  * @sample com.zachklipp.richtext.ui.string.TextPreview
  */
-@Suppress("unused")
 @Composable
 public fun RichTextScope.Text(
   text: RichTextString,
   modifier: Modifier = Modifier,
-  onTextLayout: (TextLayoutResult) -> Unit = {}
+  onTextLayout: (TextLayoutResult) -> Unit = {},
+  softWrap: Boolean = true,
+  overflow: TextOverflow = TextOverflow.Clip,
+  maxLines: Int = Int.MAX_VALUE
 ) {
   val style = currentRichTextStyle.stringStyle
   val contentColor = currentContentColor
@@ -53,60 +29,29 @@ public fun RichTextScope.Text(
     val resolvedStyle = (style ?: RichTextStringStyle.Default).resolveDefaults()
     text.toAnnotatedString(resolvedStyle, contentColor)
   }
-  val layoutResult = remember<MutableState<TextLayoutResult?>> { mutableStateOf(null) }
-  val pressIndicator = Modifier.pointerInput(Unit) {
-    detectTapGestures { position ->
-      layoutResult.value?.let { layoutResult ->
-        val offset = layoutResult.getOffsetForPosition(position)
+
+  val inlineContents = remember(text) { text.getInlineContents() }
+
+  BoxWithConstraints(modifier = modifier) {
+    val inlineTextContents = manageInlineTextContents(
+      inlineContents = inlineContents,
+      textConstraints = constraints
+    )
+
+    ClickableText(
+      text = annotated,
+      onTextLayout = onTextLayout,
+      inlineContent = inlineTextContents,
+      softWrap = softWrap,
+      overflow = overflow,
+      maxLines = maxLines,
+      onClick = { offset ->
         annotated.getStringAnnotations(Format.FormatAnnotationScope, offset, offset)
           .asSequence()
           .mapNotNull { Format.findTag(it.item, text.formatObjects) as? Link }
           .firstOrNull()
           ?.let { link -> link.onClick() }
       }
-    }
-  }
-
-  val constraintsRef = remember { Ref<Constraints>() }
-  var hack by remember(annotated) { mutableStateOf(annotated) }
-  val inlineContents = remember(text) { text.getInlineContents() }
-  // The constraints function won't be called until the content is actually composed and EM is
-  // measured, which won't happen until the text is composed.
-  val inlineTextContents = ManageInlineTextContents(
-    inlineContents = inlineContents,
-    textConstraints = { constraintsRef.value!! },
-    forceTextRelayout = {
-      // Modifying the actual string will cause Text to realize it needs to relayout.
-      // We use a special unicode character that doesn't render so there's no visual effect.
-      hack += AnnotatedString(ZERO_WIDTH_CHAR)
-    }
-  )
-
-  // This is a giant hack to work around inline content limitations:
-  // 1. We have to ask content to measure themselves with our constraints so we can generate the
-  //    correct Placeholders.
-  // 2. Text doesn't re-layout the text when the placeholders change.
-  // TODO Can this be done less hackily with SubcomposeLayout?
-  Layout(
-    modifier = modifier.then(pressIndicator),
-    content = {
-      Text(
-        text = hack,
-        onTextLayout = { result ->
-          layoutResult.value = result
-          onTextLayout(result)
-        },
-        inlineContent = inlineTextContents
-      )
-    }
-  ) { measurables, constraints ->
-    // Update the inline content before measuring text, so content will get its constraints before
-    // being measured.
-    constraintsRef.value = constraints
-
-    val p = measurables.single().measure(constraints)
-    layout(p.width, p.height) {
-      p.place(0, 0)
-    }
+    )
   }
 }


### PR DESCRIPTION
- Remove old hack, no longer necessary.
- Use BoxWithConstraints to take constraints before Text is laid out.