### PR TITLE
CodeBlock fixes

### DIFF
--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.Text
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -38,6 +39,15 @@ import com.halilibo.richtext.ui.resolveDefaults
 @Composable fun MarkdownSample() {
   var richTextStyle by remember { mutableStateOf(RichTextStyle().resolveDefaults()) }
   var isDarkModeEnabled by remember { mutableStateOf(false) }
+  var isWordWrapEnabled by remember { mutableStateOf(true) }
+
+  LaunchedEffect(isWordWrapEnabled) {
+    richTextStyle = richTextStyle.copy(
+      codeBlockStyle = richTextStyle.codeBlockStyle!!.copy(
+        wordWrap = isWordWrapEnabled
+      )
+    )
+  }
 
   val colors = if (isDarkModeEnabled) darkColors() else lightColors()
   val context = LocalContext.current
@@ -48,19 +58,22 @@ import com.halilibo.richtext.ui.resolveDefaults
         // Config
         Card(elevation = 4.dp) {
           Column {
-            Row(
-              Modifier
-                .clickable(onClick = { isDarkModeEnabled = !isDarkModeEnabled })
-                .padding(8.dp),
-              horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-              Checkbox(
-                checked = isDarkModeEnabled,
-                onCheckedChange = { isDarkModeEnabled = it },
+            CheckboxPreference(
+              onClick = {
+                isDarkModeEnabled = !isDarkModeEnabled
+              },
+              checked = isDarkModeEnabled,
+              label = "Dark Mode"
+            )
 
-                )
-              Text("Dark Mode")
-            }
+            CheckboxPreference(
+              onClick = {
+                isWordWrapEnabled = !isWordWrapEnabled
+              },
+              checked = isWordWrapEnabled,
+              label = "Word Wrap"
+            )
+
             RichTextStyleConfig(
               richTextStyle = richTextStyle,
               onChanged = { richTextStyle = it }
@@ -85,6 +98,26 @@ import com.halilibo.richtext.ui.resolveDefaults
         }
       }
     }
+  }
+}
+
+@Composable
+private fun CheckboxPreference(
+  onClick: () -> Unit,
+  checked: Boolean,
+  label: String
+) {
+  Row(
+    Modifier
+      .clickable(onClick = onClick)
+      .padding(8.dp),
+    horizontalArrangement = Arrangement.spacedBy(8.dp)
+  ) {
+    Checkbox(
+      checked = checked,
+      onCheckedChange = { onClick() },
+    )
+    Text(label)
   }
 }
 

--- a/desktop-sample/src/main/kotlin/com/halilibo/richtext/desktop/Main.kt
+++ b/desktop-sample/src/main/kotlin/com/halilibo/richtext/desktop/Main.kt
@@ -1,6 +1,8 @@
 package com.halilibo.richtext.desktop
 
+import androidx.compose.foundation.LocalScrollbarStyle
 import androidx.compose.foundation.background
+import androidx.compose.foundation.defaultScrollbarStyle
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -8,8 +10,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Surface
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -19,31 +23,41 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.singleWindowApplication
 import com.halilibo.richtext.markdown.Markdown
+import com.halilibo.richtext.ui.CodeBlockStyle
+import com.halilibo.richtext.ui.RichTextStyle
 import com.halilibo.richtext.ui.material.MaterialRichText
 
 fun main(): Unit = singleWindowApplication(
   title = "RichText KMP"
 ) {
   Surface {
-    Row(
-      modifier = Modifier.padding(32.dp).fillMaxSize(),
-      horizontalArrangement = Arrangement.spacedBy(32.dp)
-    ) {
-      var text by remember { mutableStateOf(sampleMarkdown) }
-      BasicTextField(
-        value = text,
-        onValueChange = { text = it },
-        maxLines = Int.MAX_VALUE,
-        modifier = Modifier.weight(1f)
-          .fillMaxHeight()
-          .background(Color.LightGray)
-          .padding(8.dp)
-      )
-      MaterialRichText(
-        modifier = Modifier.weight(1f)
-          .verticalScroll(rememberScrollState())
-      ) {
-        Markdown(content = text)
+    CompositionLocalProvider(LocalScrollbarStyle provides defaultScrollbarStyle().copy(
+      hoverColor = Color.DarkGray,
+      unhoverColor = Color.Gray
+    )) {
+      SelectionContainer {
+        Row(
+          modifier = Modifier.padding(32.dp).fillMaxSize(),
+          horizontalArrangement = Arrangement.spacedBy(32.dp)
+        ) {
+          var text by remember { mutableStateOf(sampleMarkdown) }
+          BasicTextField(
+            value = text,
+            onValueChange = { text = it },
+            maxLines = Int.MAX_VALUE,
+            modifier = Modifier.weight(1f)
+              .fillMaxHeight()
+              .background(Color.LightGray)
+              .padding(8.dp)
+          )
+          MaterialRichText(
+            modifier = Modifier.weight(1f)
+              .verticalScroll(rememberScrollState()),
+            style = RichTextStyle(codeBlockStyle = CodeBlockStyle(wordWrap = true))
+          ) {
+            Markdown(content = text)
+          }
+        }
       }
     }
   }

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/Markdown.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/Markdown.kt
@@ -135,10 +135,10 @@ internal fun RichTextScope.RecursiveRenderMarkdownAst(astNode: AstNode?) {
       }
     }
     is AstIndentedCodeBlock -> {
-      CodeBlock(text = astNodeType.literal)
+      CodeBlock(text = astNodeType.literal.trim())
     }
     is AstFencedCodeBlock -> {
-      CodeBlock(text = astNodeType.literal)
+      CodeBlock(text = astNodeType.literal.trim())
     }
     is AstHtmlBlock -> {
       Text(text = richTextString {

--- a/richtext-ui-material/build.gradle.kts
+++ b/richtext-ui-material/build.gradle.kts
@@ -15,7 +15,7 @@ kotlin {
         implementation(compose.runtime)
         implementation(compose.foundation)
         implementation(compose.material)
-        implementation(project(":richtext-ui"))
+        api(project(":richtext-ui"))
       }
     }
     val commonTest by getting

--- a/richtext-ui/src/androidMain/kotlin/com/halilibo/richtext/ui/CodeBlock.kt
+++ b/richtext-ui/src/androidMain/kotlin/com/halilibo/richtext/ui/CodeBlock.kt
@@ -1,0 +1,20 @@
+@file:JvmName("CodeBlockAndroid")
+package com.halilibo.richtext.ui
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+internal actual fun RichTextScope.CodeBlockLayout(
+  wordWrap: Boolean,
+  children: @Composable RichTextScope.(Modifier) -> Unit
+) {
+  if (!wordWrap) {
+    val scrollState = rememberScrollState()
+    children(Modifier.horizontalScroll(scrollState))
+  } else {
+    children(Modifier)
+  }
+}

--- a/richtext-ui/src/jvmMain/kotlin/com/halilibo/richtext/ui/CodeBlock.kt
+++ b/richtext-ui/src/jvmMain/kotlin/com/halilibo/richtext/ui/CodeBlock.kt
@@ -1,0 +1,45 @@
+@file:JvmName("CodeBlockJvm")
+package com.halilibo.richtext.ui
+
+import androidx.compose.foundation.HorizontalScrollbar
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.rememberScrollbarAdapter
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.Modifier
+
+private val LocalScrollbarEnabled = compositionLocalOf { true }
+
+@Composable
+internal actual fun RichTextScope.CodeBlockLayout(
+  wordWrap: Boolean,
+  children: @Composable RichTextScope.(Modifier) -> Unit
+) {
+  if (!wordWrap) {
+    val scrollState = rememberScrollState()
+    Column {
+      children(Modifier.horizontalScroll(scrollState))
+      if (LocalScrollbarEnabled.current) {
+        val horizontalScrollbarAdapter = rememberScrollbarAdapter(scrollState)
+        HorizontalScrollbar(adapter = horizontalScrollbarAdapter)
+      }
+    }
+  } else {
+    children(Modifier)
+  }
+}
+
+/**
+ * Contextually disables scrollbar for Desktop CodeBlocks under [content] tree.
+ */
+@Composable
+public fun DisableScrollbar(
+  content: @Composable () -> Unit
+) {
+  CompositionLocalProvider(LocalScrollbarEnabled provides false) {
+    content()
+  }
+}


### PR DESCRIPTION
Removes extra blank line at the end of a CodeBlock #55 

Adds word wrap option to CodeBlock #56 . This option can be provided by CodeBlockStyle under RichTextStyle, or directly to CodeBlock. Function parameter has priority over styling option.

Word wrapping enables scrolling of CodeBlock if its layout exceeds the available width. Desktop CodeBlock requires a horizontal scrollbar for this to work as expected. ScrollbarStyle can be controlled by LocalScrollbarStyle. Scrollbar can also be turned off by using `DisableScrollbar`.
