### PR TITLE
Bump Kotlin, Jetpack Compose, Jetbrains Compose versions

### DIFF
--- a/android-sample/build.gradle.kts
+++ b/android-sample/build.gradle.kts
@@ -20,17 +20,6 @@ android {
   }
 }
 
-configurations.all {
-  resolutionStrategy.eachDependency {
-    if (requested.group.contains("org.jetbrains.compose")) {
-      val groupName = requested.group.replace("org.jetbrains.compose", "androidx.compose")
-      useTarget(
-          mapOf("group" to groupName, "name" to requested.name, "version" to Compose.version)
-      )
-    }
-  }
-}
-
 dependencies {
   implementation(project(":printing"))
   implementation(project(":richtext-commonmark"))

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -12,6 +12,6 @@ dependencies {
   // keep in sync with Dependencies.BuildPlugins.androidGradlePlugin
   implementation("com.android.tools.build:gradle:7.0.1")
   // keep in sync with Dependencies.Kotlin.gradlePlugin
-  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21")
+  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31")
   implementation(kotlin("script-runtime"))
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -20,7 +20,7 @@ object Network {
 }
 
 object Kotlin {
-  val version = "1.5.21"
+  val version = "1.5.31"
   val binaryCompatibilityValidatorPlugin = "org.jetbrains.kotlinx:binary-compatibility-validator:0.5.0"
   val gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$version"
   val stdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
@@ -37,7 +37,7 @@ object Kotlin {
 val ktlint = "org.jlleitschuh.gradle:ktlint-gradle:10.0.0"
 
 object Compose {
-  val version = "1.0.2"
+  val version = "1.1.0-beta03"
   val activity = "androidx.activity:activity-compose:1.3.0"
   val foundation = "androidx.compose.foundation:foundation:$version"
   val layout = "androidx.compose.foundation:foundation-layout:$version"
@@ -47,8 +47,8 @@ object Compose {
   val tooling = "androidx.compose.ui:ui-tooling:$version"
   val toolingPreview = "androidx.compose.ui:ui-tooling-preview:$version"
   val toolingData = "androidx.compose.ui:ui-tooling-data:$version"
-  val desktopPreview = "org.jetbrains.compose.ui:ui-tooling-preview-desktop:1.0.0-alpha3"
-  val coil = "io.coil-kt:coil-compose:1.3.2"
+  val desktopPreview = "org.jetbrains.compose.ui:ui-tooling-preview-desktop:1.0.0-beta5"
+  val coil = "io.coil-kt:coil-compose:1.4.0"
 }
 
 object Commonmark {
@@ -60,6 +60,6 @@ object Commonmark {
 
 object AndroidConfiguration {
   val minSdk = 21
-  val targetSdk = 30
+  val targetSdk = 31
   val compileSdk = targetSdk
 }

--- a/buildSrc/src/main/kotlin/richtext-kmp-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/richtext-kmp-library.gradle.kts
@@ -19,10 +19,10 @@ kotlin {
 }
 
 android {
-  compileSdk = 30
+  compileSdk = 31
   sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
   defaultConfig {
     minSdk = 21
-    targetSdk = 30
+    targetSdk = 31
   }
 }

--- a/desktop-sample/build.gradle.kts
+++ b/desktop-sample/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 
 plugins {
   kotlin("jvm")
-  id("org.jetbrains.compose") version "1.0.0-alpha3"
+  id("org.jetbrains.compose") version "1.0.0-beta5"
 }
 
 dependencies {

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ Each library is documented separately, see the navigation menu for the list. Thi
 an API reference.
 
 !!! warning
-    This project is currently very experimental and mostly just a proof-of-concept at this point.
+    This project is currently experimental and mostly just a proof-of-concept at this point.
     There are no tests and some things might be broken or very non-performant.
 
     The API may also change between releases without deprecation cycles.
@@ -37,47 +37,6 @@ val commonMain by getting {
   }
 }
 ```
-
-### Android 
-
-Desktop Compose and Jetpack Compose for Android use the same modules but they are published under separate 
-artifacts. `org.jetbrains.compose` plugin replaces all `androidx.compose` dependencies with their `org.jetbrains.compose` counterparts.
-If this is not done, gradle build fails with too many **Duplicate Class** errors.
-
-On the other hand, applying a KMP plugin in a pure Android App might not be the desired approach. Adding the following
-configuration to `build.gradle` file in an Android module that depends on any of `RichText` KMP libraries would solve the problem as well.
-
-=== "Groovy"
-    ```groovy
-    configurations.all {
-      resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-        if (details.requested.group.contains('org.jetbrains.compose')) {
-          def groupName = details.requested.group.replace("org.jetbrains.compose", "androidx.compose")
-          details.useTarget(
-              [group: groupName, name: details.requested.name, version: composeVersion] // compose version in your project
-          )
-        }
-      }
-    }
-    ```
-
-=== "Kotlin"
-    ``` kotlin
-    configurations.all {
-      resolutionStrategy.eachDependency {
-        if (requested.group.contains("org.jetbrains.compose")) {
-          val groupName = requested.group.replace("org.jetbrains.compose", "androidx.compose")
-          useTarget("$groupName:${requested.name}:${composeVersion}") // compose version in your project
-        }
-      }
-    }
-    ```
-
-Most importantly, this problem seems to be temporary. Jetbrains team is actively working on it.
-
-[A comment from Jetbrains in Compose Plugin docs.](https://github.com/JetBrains/compose-jb/blob/master/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt#L79)
-
-> It is temporarily solution until we will be publishing all MPP artifacts in Google Maven repository. Or align versions with androidx artifacts and point MPP-android artifacts to androidx artifacts (is it possible?)
 
 ### Library Artifacts
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 
 GROUP=com.halilibo.compose-richtext
-VERSION_NAME=0.8.1
+VERSION_NAME=0.9.0
 
 POM_DESCRIPTION=A collection of Compose libraries for advanced text formatting and alternative display types.
 

--- a/richtext-commonmark/build.gradle.kts
+++ b/richtext-commonmark/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("richtext-kmp-library")
-  id("org.jetbrains.compose") version "1.0.0-alpha3"
+  id("org.jetbrains.compose") version "1.0.0-beta5"
   id("org.jetbrains.dokka")
 }
 

--- a/richtext-commonmark/src/jvmMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
+++ b/richtext-commonmark/src/jvmMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
@@ -7,10 +7,11 @@ import androidx.compose.runtime.produceState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.toComposeImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.jetbrains.skija.Image.makeFromEncoded
+import org.jetbrains.skia.Image.Companion.makeFromEncoded
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
@@ -27,7 +28,7 @@ internal actual fun RemoteImage(
 ) {
   val image by produceState<ImageBitmap?>(null, url) {
     loadFullImage(url)?.let {
-      value = makeFromEncoded(toByteArray(it)).asImageBitmap()
+      value = makeFromEncoded(toByteArray(it)).toComposeImageBitmap()
     }
   }
 

--- a/richtext-ui-material/build.gradle.kts
+++ b/richtext-ui-material/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("richtext-kmp-library")
-  id("org.jetbrains.compose") version "1.0.0-alpha3"
+  id("org.jetbrains.compose") version "1.0.0-beta5"
   id("org.jetbrains.dokka")
 }
 

--- a/richtext-ui/build.gradle.kts
+++ b/richtext-ui/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("richtext-kmp-library")
-  id("org.jetbrains.compose") version "1.0.0-alpha3"
+  id("org.jetbrains.compose") version "1.0.0-beta5"
   id("org.jetbrains.dokka")
 }
 

--- a/slideshow/src/main/java/com/zachklipp/richtext/ui/slideshow/Slideshow.kt
+++ b/slideshow/src/main/java/com/zachklipp/richtext/ui/slideshow/Slideshow.kt
@@ -13,6 +13,7 @@ import android.view.View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
@@ -167,8 +168,8 @@ public class SlideshowController {
           modifier = Modifier
             .fillMaxSize()
             .wrapContentSize(align = Alignment.BottomCenter),
-          enter = slideInVertically({ it }),
-          exit = slideOutVertically({ it })
+          enter = slideInVertically(spring()) { it },
+          exit = slideOutVertically(spring()) { it }
         ) {
           SlideshowScrubber(controller, slides)
         }


### PR DESCRIPTION
- Increase targetSdk to 31
- Remove Android KMP Compose workaround
- Update docs to remove the mention of workaround