### PR TITLE
Allow null title in image

### DIFF
--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
@@ -243,7 +243,9 @@ private val sampleMarkdown = """
 
   ## Images
   
-  Inline-style: 
+  Inline-style:
+   
+  ![random image](https://picsum.photos/seed/picsum/400/400)
   
   ![random image](https://picsum.photos/seed/picsum/400/400 "Text 1")
   

--- a/richtext-commonmark/build.gradle.kts
+++ b/richtext-commonmark/build.gradle.kts
@@ -41,5 +41,12 @@ kotlin {
         implementation(Commonmark.strikethrough)
       }
     }
+
+    val jvmTest by getting {
+      kotlin.srcDir("src/commonJvmAndroidTest/kotlin")
+      dependencies {
+        implementation(Kotlin.Test.jdk)
+      }
+    }
   }
 }

--- a/richtext-commonmark/src/commonJvmAndroid/kotlin/com/halilibo/richtext/markdown/AstNodeConvert.kt
+++ b/richtext-commonmark/src/commonJvmAndroid/kotlin/com/halilibo/richtext/markdown/AstNodeConvert.kt
@@ -112,12 +112,12 @@ internal fun convert(
       literal = node.literal
     )
     is Image -> {
-      if (node.title == null || node.destination == null) {
+      if (node.destination == null) {
         null
       }
       else {
         AstImage(
-          title = node.title,
+          title = node.title ?: "",
           destination = node.destination
         )
       }

--- a/richtext-commonmark/src/commonJvmAndroidTest/kotlin/com/halilibo/richtext/markdown/AstNodeConvertKtTest.kt
+++ b/richtext-commonmark/src/commonJvmAndroidTest/kotlin/com/halilibo/richtext/markdown/AstNodeConvertKtTest.kt
@@ -1,0 +1,27 @@
+package com.halilibo.richtext.markdown
+
+import com.halilibo.richtext.markdown.node.AstImage
+import com.halilibo.richtext.markdown.node.AstNode
+import com.halilibo.richtext.markdown.node.AstNodeLinks
+import org.commonmark.node.Image
+import org.junit.Test
+import kotlin.test.assertEquals
+
+internal class AstNodeConvertKtTest {
+
+  @Test
+  fun `when image without title is converted, then the content description is empty`() {
+    val destination = "/url"
+    val image = Image(destination, null)
+
+    val result = convert(image)
+
+    assertEquals(
+      expected = AstNode(
+        type = AstImage(title = "", destination = destination),
+        links = AstNodeLinks()
+      ),
+      actual = result
+    )
+  }
+}


### PR DESCRIPTION
### Summary
Currently the Markdown below does not render an image, because the parser is expecting a `title`:
```
Does not work: ![random image](https://picsum.photos/seed/picsum/400/400)

Works: ![random image](https://picsum.photos/seed/picsum/400/400 "title")
```

The CommonMark library does not take the 'random image' as alternative text, so passes a `null` title. The `convert()` function does not render the picture at all, because it currently requires the `title`.

I changed the `title` to optional and provide an empty string as content description in this case, so at least the picture is rendered.

Also see [the comment on this issue](https://github.com/halilozercan/compose-richtext/issues/65#issuecomment-1122137490).