### PR TITLE
Update RichText to latest versions of Jetpack Compose and Desktop

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,7 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <option name="USE_SAME_INDENTS" value="true" />
-    <option name="IGNORE_SAME_INDENTS_FOR_LANGUAGES" value="true" />
     <option name="OTHER_INDENT_OPTIONS">
       <value>
         <option name="INDENT_SIZE" value="2" />
@@ -21,11 +19,11 @@
         <package name="" withSubpackages="true" static="true" />
       </value>
     </option>
+    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
     <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
     <option name="BLOCK_COMMENT_AT_FIRST_COLUMN" value="false" />
     <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
-    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
     <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
     <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
     <option name="ALIGN_MULTILINE_FOR" value="false" />
@@ -96,9 +94,6 @@
       <option name="IMPORT_NESTED_CLASSES" value="true" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
-    <XML>
-      <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
-    </XML>
     <ADDITIONAL_INDENT_OPTIONS fileType="php">
       <option name="INDENT_SIZE" value="2" />
       <option name="CONTINUATION_INDENT_SIZE" value="4" />

--- a/android-sample/build.gradle.kts
+++ b/android-sample/build.gradle.kts
@@ -15,6 +15,8 @@ android {
     compose = true
   }
 
+  kotlinOptions { jvmTarget = "11" }
+
   composeOptions {
     kotlinCompilerExtensionVersion = Compose.version
   }

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/SampleLauncher.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/SampleLauncher.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.ExperimentalMaterialApi
@@ -61,8 +62,8 @@ private val Samples = listOf<Pair<String, @Composable () -> Unit>>(
       topBar = {
         TopAppBar(title = { Text("Samples") })
       }
-    ) {
-      LazyColumn {
+    ) { contentPadding ->
+      LazyColumn(modifier = Modifier.padding(contentPadding)) {
         itemsIndexed(Samples) { index, (title, sampleContent) ->
           ListItem(
             Modifier.clickable(onClick = { onSampleClicked(index) }),

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ buildscript {
 }
 
 plugins {
-  id("org.jetbrains.dokka") version "1.6.0"
+  id("org.jetbrains.dokka") version "1.6.21"
 }
 
 repositories {
@@ -53,7 +53,7 @@ subprojects {
         allWarningsAsErrors = true
       }
 
-      freeCompilerArgs = listOf("-Xopt-in=kotlin.RequiresOptIn")
+      freeCompilerArgs = listOf("-opt-in=kotlin.RequiresOptIn")
     }
   }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
   // keep in sync with Dependencies.BuildPlugins.androidGradlePlugin
-  implementation("com.android.tools.build:gradle:7.0.3")
+  implementation("com.android.tools.build:gradle:7.4.0-alpha01")
   // keep in sync with Dependencies.Kotlin.gradlePlugin
-  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31")
+  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21")
   implementation(kotlin("script-runtime"))
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,16 +1,16 @@
 object BuildPlugins {
-  val androidGradlePlugin = "com.android.tools.build:gradle:7.0.3"
+  val androidGradlePlugin = "com.android.tools.build:gradle:7.4.0-alpha01"
 }
 
 object AndroidX {
-  val activity = "androidx.activity:activity:1.1.0"
+  val activity = "androidx.activity:activity:1.5.0-rc01"
   val annotations = "androidx.annotation:annotation:1.1.0"
   val appcompat = "androidx.appcompat:appcompat:1.3.0"
   val constraintLayout = "androidx.constraintlayout:constraintlayout:1.1.3"
   val fragment = "androidx.fragment:fragment:1.2.2"
   val material = "com.google.android.material:material:1.1.0"
   val recyclerview = "androidx.recyclerview:recyclerview:1.1.0"
-  val savedstate = "androidx.savedstate:savedstate:1.0.0"
+  val savedstate = "androidx.savedstate:savedstate-ktx:1.2.0-rc01"
   val transition = "androidx.transition:transition:1.3.1"
   val viewbinding = "androidx.databinding:viewbinding:3.6.1"
 }
@@ -20,8 +20,8 @@ object Network {
 }
 
 object Kotlin {
-  val version = "1.5.31"
-  val binaryCompatibilityValidatorPlugin = "org.jetbrains.kotlinx:binary-compatibility-validator:0.5.0"
+  val version = "1.6.21"
+  val binaryCompatibilityValidatorPlugin = "org.jetbrains.kotlinx:binary-compatibility-validator:0.9.0"
   val gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$version"
 
   object Test {
@@ -35,8 +35,8 @@ object Kotlin {
 val ktlint = "org.jlleitschuh.gradle:ktlint-gradle:10.0.0"
 
 object Compose {
-  val version = "1.1.0-beta03"
-  val activity = "androidx.activity:activity-compose:1.3.0"
+  val version = "1.2.0-beta01"
+  val activity = "androidx.activity:activity-compose:1.5.0-rc01"
   val foundation = "androidx.compose.foundation:foundation:$version"
   val layout = "androidx.compose.foundation:foundation-layout:$version"
   val material = "androidx.compose.material:material:$version"
@@ -58,6 +58,6 @@ object Commonmark {
 
 object AndroidConfiguration {
   val minSdk = 21
-  val targetSdk = 31
+  val targetSdk = 32
   val compileSdk = targetSdk
 }

--- a/buildSrc/src/main/kotlin/richtext-android-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/richtext-android-library.gradle.kts
@@ -17,6 +17,8 @@ android {
     targetSdk = AndroidConfiguration.targetSdk
   }
 
+  kotlinOptions { jvmTarget = "11" }
+
   buildFeatures {
     compose = true
   }

--- a/buildSrc/src/main/kotlin/richtext-kmp-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/richtext-kmp-library.gradle.kts
@@ -19,10 +19,10 @@ kotlin {
 }
 
 android {
-  compileSdk = 31
+  compileSdk = 32
   sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
   defaultConfig {
     minSdk = 21
-    targetSdk = 31
+    targetSdk = compileSdk
   }
 }

--- a/desktop-sample/build.gradle.kts
+++ b/desktop-sample/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 
 plugins {
   kotlin("jvm")
-  id("org.jetbrains.compose") version "1.0.0"
+  id("org.jetbrains.compose") version "1.2.0-alpha01-dev683"
 }
 
 dependencies {

--- a/desktop-sample/src/main/kotlin/com/halilibo/richtext/desktop/Main.kt
+++ b/desktop-sample/src/main/kotlin/com/halilibo/richtext/desktop/Main.kt
@@ -4,15 +4,21 @@ import androidx.compose.foundation.LocalScrollbarStyle
 import androidx.compose.foundation.background
 import androidx.compose.foundation.defaultScrollbarStyle
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Slider
 import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -20,44 +26,136 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.singleWindowApplication
 import com.halilibo.richtext.markdown.Markdown
 import com.halilibo.richtext.ui.CodeBlockStyle
+import com.halilibo.richtext.ui.RichText
 import com.halilibo.richtext.ui.RichTextStyle
+import com.halilibo.richtext.ui.Table
 import com.halilibo.richtext.ui.material.MaterialRichText
+import com.halilibo.richtext.ui.resolveDefaults
 
 fun main(): Unit = singleWindowApplication(
   title = "RichText KMP"
 ) {
+  var richTextStyle by remember {
+    mutableStateOf(
+      RichTextStyle(
+        codeBlockStyle = CodeBlockStyle(wordWrap = true)
+      ).resolveDefaults()
+    )
+  }
+
   Surface {
-    CompositionLocalProvider(LocalScrollbarStyle provides defaultScrollbarStyle().copy(
-      hoverColor = Color.DarkGray,
-      unhoverColor = Color.Gray
-    )) {
+    CompositionLocalProvider(
+      LocalScrollbarStyle provides defaultScrollbarStyle().copy(
+        hoverColor = Color.DarkGray,
+        unhoverColor = Color.Gray
+      )
+    ) {
       SelectionContainer {
+        var text by remember { mutableStateOf(sampleMarkdown) }
         Row(
-          modifier = Modifier.padding(32.dp).fillMaxSize(),
+          modifier = Modifier
+            .padding(32.dp)
+            .fillMaxSize(),
           horizontalArrangement = Arrangement.spacedBy(32.dp)
         ) {
-          var text by remember { mutableStateOf(sampleMarkdown) }
-          BasicTextField(
-            value = text,
-            onValueChange = { text = it },
-            maxLines = Int.MAX_VALUE,
-            modifier = Modifier.weight(1f)
-              .fillMaxHeight()
-              .background(Color.LightGray)
-              .padding(8.dp)
-          )
+          Column(modifier = Modifier.weight(1f)) {
+            RichTextStyleConfig(richTextStyle = richTextStyle, onChanged = { richTextStyle = it })
+            BasicTextField(
+              value = text,
+              onValueChange = { text = it },
+              maxLines = Int.MAX_VALUE,
+              modifier = Modifier
+                .fillMaxHeight()
+                .background(Color.LightGray)
+                .padding(8.dp)
+            )
+          }
           MaterialRichText(
-            modifier = Modifier.weight(1f)
+            modifier = Modifier
+              .weight(1f)
               .verticalScroll(rememberScrollState()),
-            style = RichTextStyle(codeBlockStyle = CodeBlockStyle(wordWrap = true))
+            style = richTextStyle
           ) {
             Markdown(content = text)
           }
         }
+      }
+    }
+  }
+}
+
+@Composable
+fun RichTextStyleConfig(
+  richTextStyle: RichTextStyle,
+  onChanged: (RichTextStyle) -> Unit
+) {
+  Column(modifier = Modifier.fillMaxWidth()) {
+    Row {
+      Column(Modifier.weight(1f)) {
+        Text("Paragraph spacing:\n${richTextStyle.paragraphSpacing}")
+        Slider(
+          value = richTextStyle.paragraphSpacing!!.value,
+          valueRange = 0f..20f,
+          onValueChange = {
+            onChanged(richTextStyle.copy(paragraphSpacing = it.sp))
+          }
+        )
+      }
+      Column(Modifier.weight(1f)) {
+        Text("List item spacing:\n${richTextStyle.listStyle!!.itemSpacing}")
+        Slider(
+          value = richTextStyle.listStyle!!.itemSpacing!!.value,
+          valueRange = 0f..20f,
+          onValueChange = {
+            onChanged(
+              richTextStyle.copy(
+                listStyle = richTextStyle.listStyle!!.copy(
+                  itemSpacing = it.sp
+                )
+              )
+            )
+          }
+        )
+      }
+    }
+    Row {
+      Column(Modifier.weight(1f)) {
+        Text("Table cell padding:\n${richTextStyle.tableStyle!!.cellPadding}")
+        Slider(
+          value = richTextStyle.tableStyle!!.cellPadding!!.value,
+          valueRange = 0f..20f,
+          onValueChange = {
+            onChanged(
+              richTextStyle.copy(
+                tableStyle = richTextStyle.tableStyle!!.copy(
+                  cellPadding = it.sp
+                )
+              )
+            )
+          }
+        )
+      }
+      Column(Modifier.weight(1f)) {
+        Text("Table border width padding:\n${richTextStyle.tableStyle!!.borderStrokeWidth!!}")
+        Slider(
+          value = richTextStyle.tableStyle!!.borderStrokeWidth!!,
+          valueRange = 0f..20f,
+          onValueChange = {
+            onChanged(
+              richTextStyle.copy(
+                tableStyle = richTextStyle.tableStyle!!.copy(
+                  borderStrokeWidth = it
+                )
+              )
+            )
+          }
+        )
       }
     }
   }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/printing/build.gradle.kts
+++ b/printing/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
   implementation(Compose.tooling)
   // For slot table analysis.
   implementation(Compose.toolingData)
-  implementation(AndroidX.activity)
+  implementation(Compose.activity)
 
   // TODO Migrate off this.
   implementation(Compose.material)

--- a/printing/src/main/java/com/zachklipp/richtext/ui/printing/ComposePdfRenderer.kt
+++ b/printing/src/main/java/com/zachklipp/richtext/ui/printing/ComposePdfRenderer.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
 import androidx.lifecycle.ViewTreeLifecycleOwner
 import androidx.lifecycle.ViewTreeViewModelStoreOwner
-import androidx.savedstate.ViewTreeSavedStateRegistryOwner
+import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -177,7 +177,7 @@ private fun createWindowComposeView(
 ): View = ComposeView(activity).apply {
   ViewTreeLifecycleOwner.set(this, activity)
   ViewTreeViewModelStoreOwner.set(this, activity)
-  ViewTreeSavedStateRegistryOwner.set(this, activity)
+  setViewTreeSavedStateRegistryOwner(activity)
   setContent(content)
 }
 

--- a/richtext-commonmark/build.gradle.kts
+++ b/richtext-commonmark/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("richtext-kmp-library")
-  id("org.jetbrains.compose") version "1.0.0"
+  id("org.jetbrains.compose") version "1.2.0-alpha01-dev683"
   id("org.jetbrains.dokka")
 }
 

--- a/richtext-commonmark/src/jvmMain/kotlin/com/halilibo/richtext/markdown/HtmlBlock.kt
+++ b/richtext-commonmark/src/jvmMain/kotlin/com/halilibo/richtext/markdown/HtmlBlock.kt
@@ -2,11 +2,12 @@ package com.halilibo.richtext.markdown
 
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 
 @Composable
 internal actual fun HtmlBlock(content: String) {
-  SideEffect {
+  LaunchedEffect(Unit) {
     println("Html blocks are rendered literally in Compose Desktop!")
   }
   BasicText(content)

--- a/richtext-ui-material/build.gradle.kts
+++ b/richtext-ui-material/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("richtext-kmp-library")
-  id("org.jetbrains.compose") version "1.0.0"
+  id("org.jetbrains.compose") version "1.2.0-alpha01-dev683"
   id("org.jetbrains.dokka")
 }
 

--- a/richtext-ui/build.gradle.kts
+++ b/richtext-ui/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("richtext-kmp-library")
-  id("org.jetbrains.compose") version "1.0.0"
+  id("org.jetbrains.compose") version "1.2.0-alpha01-dev683"
   id("org.jetbrains.dokka")
 }
 


### PR DESCRIPTION
Update RichText to latest versions of Jetpack Compose and Compose Desktop

- Update Android Gradle Plugin
- Update Kotlin version
- Add itemSpacing to RichTextStyle.ListStyle
- Change SideEffect logging to LaunchedEffect