### PR TITLE
Revert back to stable releases of both Jetpack and Jetbrains Compose

### DIFF
--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
@@ -108,10 +109,9 @@ private fun CheckboxPreference(
   label: String
 ) {
   Row(
-    Modifier
-      .clickable(onClick = onClick)
-      .padding(8.dp),
-    horizontalArrangement = Arrangement.spacedBy(8.dp)
+    Modifier.clickable(onClick = onClick),
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+    verticalAlignment = Alignment.CenterVertically
   ) {
     Checkbox(
       checked = checked,

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/RichTextSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/RichTextSample.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -49,7 +50,8 @@ import com.halilibo.richtext.ui.resolveDefaults
               Modifier
                 .clickable(onClick = { isDarkModeEnabled = !isDarkModeEnabled })
                 .padding(8.dp),
-              horizontalArrangement = Arrangement.spacedBy(8.dp)
+              horizontalArrangement = Arrangement.spacedBy(8.dp),
+              verticalAlignment = Alignment.CenterVertically
             ) {
               Checkbox(
                 checked = isDarkModeEnabled,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ buildscript {
 }
 
 plugins {
-  id("org.jetbrains.dokka") version "1.6.21"
+  id("org.jetbrains.dokka") version "1.6.10"
 }
 
 repositories {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -12,6 +12,6 @@ dependencies {
   // keep in sync with Dependencies.BuildPlugins.androidGradlePlugin
   implementation("com.android.tools.build:gradle:7.4.0-alpha01")
   // keep in sync with Dependencies.Kotlin.gradlePlugin
-  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21")
+  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10")
   implementation(kotlin("script-runtime"))
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -20,7 +20,7 @@ object Network {
 }
 
 object Kotlin {
-  val version = "1.6.21"
+  val version = "1.6.10"
   val binaryCompatibilityValidatorPlugin = "org.jetbrains.kotlinx:binary-compatibility-validator:0.9.0"
   val gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$version"
 
@@ -35,11 +35,12 @@ object Kotlin {
 val ktlint = "org.jlleitschuh.gradle:ktlint-gradle:10.0.0"
 
 object Compose {
-  val version = "1.2.0-beta01"
+  val version = "1.1.1"
   val activity = "androidx.activity:activity-compose:1.5.0-rc01"
   val foundation = "androidx.compose.foundation:foundation:$version"
   val layout = "androidx.compose.foundation:foundation-layout:$version"
   val material = "androidx.compose.material:material:$version"
+  val material3 = "androidx.compose.material3:material3:1.0.0-alpha13"
   val icons = "androidx.compose.material:material-icons-extended:$version"
   val test = "androidx.ui:ui-test:$version"
   val tooling = "androidx.compose.ui:ui-tooling:$version"

--- a/desktop-sample/build.gradle.kts
+++ b/desktop-sample/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 
 plugins {
   kotlin("jvm")
-  id("org.jetbrains.compose") version "1.2.0-alpha01-dev683"
+  id("org.jetbrains.compose") version "1.1.1"
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 
 GROUP=com.halilibo.compose-richtext
-VERSION_NAME=0.12.0
+VERSION_NAME=0.13.0
 
 POM_DESCRIPTION=A collection of Compose libraries for advanced text formatting and alternative display types.
 

--- a/richtext-commonmark/build.gradle.kts
+++ b/richtext-commonmark/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("richtext-kmp-library")
-  id("org.jetbrains.compose") version "1.2.0-alpha01-dev683"
+  id("org.jetbrains.compose") version "1.1.1"
   id("org.jetbrains.dokka")
 }
 

--- a/richtext-ui-material/build.gradle.kts
+++ b/richtext-ui-material/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("richtext-kmp-library")
-  id("org.jetbrains.compose") version "1.2.0-alpha01-dev683"
+  id("org.jetbrains.compose") version "1.1.1"
   id("org.jetbrains.dokka")
 }
 

--- a/richtext-ui/build.gradle.kts
+++ b/richtext-ui/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("richtext-kmp-library")
-  id("org.jetbrains.compose") version "1.2.0-alpha01-dev683"
+  id("org.jetbrains.compose") version "1.1.1"
   id("org.jetbrains.dokka")
 }
 

--- a/richtext-ui/src/androidMain/AndroidManifest.xml
+++ b/richtext-ui/src/androidMain/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.zachklipp.richtext.ui" />
+<manifest package="com.halilibo.richtext.ui" />

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
@@ -176,8 +176,8 @@ private val LocalListLevel = compositionLocalOf { 0 }
 /**
  * Creates a formatted list such as a bullet list or numbered list.
  *
- * @sample com.zachklipp.richtext.ui.OrderedListPreview
- * @sample com.zachklipp.richtext.ui.UnorderedListPreview
+ * @sample com.halilibo.richtext.ui.previews.OrderedListPreview
+ * @sample com.halilibo.richtext.ui.previews.UnorderedListPreview
  */
 // inline is required for https://github.com/halilozercan/compose-richtext/issues/7
 @Suppress("NOTHING_TO_INLINE")
@@ -189,8 +189,8 @@ private val LocalListLevel = compositionLocalOf { 0 }
 /**
  * Creates a formatted list such as a bullet list or numbered list.
  *
- * @sample com.zachklipp.richtext.ui.OrderedListPreview
- * @sample com.zachklipp.richtext.ui.UnorderedListPreview
+ * @sample com.halilibo.richtext.ui.previews.OrderedListPreview
+ * @sample com.halilibo.richtext.ui.previews.UnorderedListPreview
  */
 @Composable public fun <T> RichTextScope.FormattedList(
   listType: ListType,

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/RichTextStyle.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/RichTextStyle.kt
@@ -21,7 +21,7 @@ internal val DefaultParagraphSpacing: TextUnit = 8.sp
  * @param codeBlockStyle The [CodeBlockStyle] that defines how [CodeBlock]s are drawn.
  * @param tableStyle The [TableStyle] used to render [Table]s.
  * @param stringStyle The [RichTextStringStyle] used to render
- * [RichTextString][com.zachklipp.richtext.ui.string.RichTextString]s
+ * [RichTextString][com.halilibo.richtext.ui.string.RichTextString]s
  */
 @Immutable
 public data class RichTextStyle(


### PR DESCRIPTION
- Revert Kotlin version to 1.1.1

It turns out that Jetbrains intermediate releases between stable versions require specifically adding Jetbrains maven repository to be able to use RichText in other projects. 

Hence, this project is going to have two ongoing releases at the same time. 

1) 0.x.y - Uses only stable releases of both Compose libraries. Requires no other setup
2) 0.x+1.y-[alpha|beta|rc] - Uses the latest compatible releases.