### PR TITLE
0.14.0 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [![Maven Central](https://img.shields.io/maven-central/v/com.halilibo.compose-richtext/richtext-ui.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.halilibo.compose-richtext%22)
 [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0)
 
+> **Warning**
+> compose-richtext library and all its modules are very experimental and undermaintained. The roadmap is unclear at the moment. Thanks for your patience. Fork option is available as always.
+
 A collection of Compose libraries for working with rich text formatting and documents.
 
 `richtext-ui`, `richtext-commonmark`, and `richtext-material-ui` are Kotlin Multiplatform Compose Libraries.
@@ -41,7 +44,7 @@ might be broken or very non-performant.
 
 ## License
 ```
-Copyright 2020 Halil Ozercan
+Copyright 2022 Halil Ozercan
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/android-sample/build.gradle.kts
+++ b/android-sample/build.gradle.kts
@@ -7,7 +7,7 @@ android {
   compileSdk = AndroidConfiguration.compileSdk
 
   defaultConfig {
-    minSdk = 21
+    minSdk = AndroidConfiguration.minSdk
     targetSdk = AndroidConfiguration.targetSdk
   }
 
@@ -18,7 +18,7 @@ android {
   kotlinOptions { jvmTarget = "11" }
 
   composeOptions {
-    kotlinCompilerExtensionVersion = Compose.version
+    kotlinCompilerExtensionVersion = Compose.compilerVersion
   }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ buildscript {
 }
 
 plugins {
-  id("org.jetbrains.dokka") version "1.6.10"
+  id("org.jetbrains.dokka") version "1.7.10"
 }
 
 repositories {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
   // keep in sync with Dependencies.BuildPlugins.androidGradlePlugin
-  implementation("com.android.tools.build:gradle:7.4.0-alpha01")
+  implementation("com.android.tools.build:gradle:7.2.2")
   // keep in sync with Dependencies.Kotlin.gradlePlugin
-  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10")
+  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10")
   implementation(kotlin("script-runtime"))
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,5 +1,5 @@
 object BuildPlugins {
-  val androidGradlePlugin = "com.android.tools.build:gradle:7.4.0-alpha01"
+  val androidGradlePlugin = "com.android.tools.build:gradle:7.2.2"
 }
 
 object AndroidX {
@@ -20,7 +20,7 @@ object Network {
 }
 
 object Kotlin {
-  val version = "1.6.10"
+  val version = "1.7.10"
   val binaryCompatibilityValidatorPlugin = "org.jetbrains.kotlinx:binary-compatibility-validator:0.9.0"
   val gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$version"
 
@@ -35,23 +35,22 @@ object Kotlin {
 val ktlint = "org.jlleitschuh.gradle:ktlint-gradle:10.0.0"
 
 object Compose {
-  val version = "1.1.1"
-  val activity = "androidx.activity:activity-compose:1.5.0-rc01"
+  val version = "1.2.1"
+  val compilerVersion = "1.3.1"
+  val activity = "androidx.activity:activity-compose:1.6.0-rc01"
   val foundation = "androidx.compose.foundation:foundation:$version"
-  val layout = "androidx.compose.foundation:foundation-layout:$version"
   val material = "androidx.compose.material:material:$version"
-  val material3 = "androidx.compose.material3:material3:1.0.0-alpha13"
+  val material3 = "androidx.compose.material3:material3:1.0.0-beta02"
   val icons = "androidx.compose.material:material-icons-extended:$version"
   val test = "androidx.ui:ui-test:$version"
   val tooling = "androidx.compose.ui:ui-tooling:$version"
-  val toolingPreview = "androidx.compose.ui:ui-tooling-preview:$version"
   val toolingData = "androidx.compose.ui:ui-tooling-data:$version"
-  val desktopPreview = "org.jetbrains.compose.ui:ui-tooling-preview-desktop:1.0.0"
-  val coil = "io.coil-kt:coil-compose:2.0.0"
+  val desktopPreview = "org.jetbrains.compose.ui:ui-tooling-preview-desktop:1.2.0-alpha01-dev620"
+  val coil = "io.coil-kt:coil-compose:2.2.1"
 }
 
 object Commonmark {
-  private val version = "0.18.0"
+  private val version = "0.19.0"
   val core = "org.commonmark:commonmark:$version"
   val tables = "org.commonmark:commonmark-ext-gfm-tables:$version"
   val strikethrough = "org.commonmark:commonmark-ext-gfm-strikethrough:$version"
@@ -59,6 +58,6 @@ object Commonmark {
 
 object AndroidConfiguration {
   val minSdk = 21
-  val targetSdk = 32
+  val targetSdk = 33
   val compileSdk = targetSdk
 }

--- a/buildSrc/src/main/kotlin/richtext-android-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/richtext-android-library.gradle.kts
@@ -13,7 +13,7 @@ android {
   compileSdk = AndroidConfiguration.compileSdk
 
   defaultConfig {
-    minSdk = 21
+    minSdk = AndroidConfiguration.minSdk
     targetSdk = AndroidConfiguration.targetSdk
   }
 
@@ -24,6 +24,6 @@ android {
   }
 
   composeOptions {
-    kotlinCompilerExtensionVersion = Compose.version
+    kotlinCompilerExtensionVersion = Compose.compilerVersion
   }
 }

--- a/buildSrc/src/main/kotlin/richtext-kmp-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/richtext-kmp-library.gradle.kts
@@ -19,7 +19,7 @@ kotlin {
 }
 
 android {
-  compileSdk = 32
+  compileSdk = 33
   sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
   defaultConfig {
     minSdk = 21

--- a/desktop-sample/build.gradle.kts
+++ b/desktop-sample/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 
 plugins {
   kotlin("jvm")
-  id("org.jetbrains.compose") version "1.1.1"
+  id("org.jetbrains.compose") version "1.2.0-alpha01-dev764"
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 
 GROUP=com.halilibo.compose-richtext
-VERSION_NAME=0.13.0
+VERSION_NAME=0.14.0
 
 POM_DESCRIPTION=A collection of Compose libraries for advanced text formatting and alternative display types.
 

--- a/richtext-commonmark/build.gradle.kts
+++ b/richtext-commonmark/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("richtext-kmp-library")
-  id("org.jetbrains.compose") version "1.1.1"
+  id("org.jetbrains.compose") version "1.2.0-alpha01-dev764"
   id("org.jetbrains.dokka")
 }
 

--- a/richtext-ui-material/build.gradle.kts
+++ b/richtext-ui-material/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("richtext-kmp-library")
-  id("org.jetbrains.compose") version "1.1.1"
+  id("org.jetbrains.compose") version "1.2.0-alpha01-dev764"
   id("org.jetbrains.dokka")
 }
 

--- a/richtext-ui-material3/build.gradle.kts
+++ b/richtext-ui-material3/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("richtext-kmp-library")
-  id("org.jetbrains.compose") version "1.1.1"
+  id("org.jetbrains.compose") version "1.2.0-alpha01-dev764"
   id("org.jetbrains.dokka")
 }
 

--- a/richtext-ui/build.gradle.kts
+++ b/richtext-ui/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("richtext-kmp-library")
-  id("org.jetbrains.compose") version "1.1.1"
+  id("org.jetbrains.compose") version "1.2.0-alpha01-dev764"
   id("org.jetbrains.dokka")
 }
 

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/RichTextString.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/RichTextString.kt
@@ -219,18 +219,7 @@ public data class RichTextString internal constructor(
       override fun getStyle(
         richTextStyle: RichTextStringStyle,
         contentColor: Color
-      ) = richTextStyle.linkStyle!!.let { style ->
-        // Tweak the colors a bit to make it more likely to contrast with the background color.
-        val averagedValues = Color(
-          red = ((contentColor.red + style.color.red) * .5f
-              + style.color.red * .5f).coerceAtMost(1f),
-          green = ((contentColor.green + style.color.green) * .5f
-              + style.color.green * .5f).coerceAtMost(1f),
-          blue = ((contentColor.blue + style.color.blue) * .5f
-              + style.color.blue * .5f).coerceAtMost(1f)
-        )
-        style.copy(color = averagedValues)
-      }
+      ) = richTextStyle.linkStyle
 
       internal companion object {
         val DefaultStyle = SpanStyle(


### PR DESCRIPTION
Update Compose to 1.2.1

main branch will use the latest stable versions.

Kotlin: 1.7.10
AGP: 7.2.2
Compose compiler: 1.3.1
Jetpack Compose: 1.2.1
Jetbrains Compose: 1.2.0-alpha01-dev764
Coil: 2.2.1
Commonmark: 0.19.0

- Removed linkStyle modification according to contentColor. Fixes #88
- Added a warning note to readme about the overall situation of the project.