### PR TITLE
Bump Compose Multiplatform version to 1.2.0

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -37,6 +37,7 @@ val ktlint = "org.jlleitschuh.gradle:ktlint-gradle:10.0.0"
 object Compose {
   val version = "1.2.1"
   val compilerVersion = "1.3.1"
+  val desktopVersion = "1.2.0"
   val activity = "androidx.activity:activity-compose:1.6.0-rc01"
   val foundation = "androidx.compose.foundation:foundation:$version"
   val material = "androidx.compose.material:material:$version"
@@ -45,7 +46,7 @@ object Compose {
   val test = "androidx.ui:ui-test:$version"
   val tooling = "androidx.compose.ui:ui-tooling:$version"
   val toolingData = "androidx.compose.ui:ui-tooling-data:$version"
-  val desktopPreview = "org.jetbrains.compose.ui:ui-tooling-preview-desktop:1.2.0-alpha01-dev620"
+  val desktopPreview = "org.jetbrains.compose.ui:ui-tooling-preview-desktop:$desktopVersion"
   val coil = "io.coil-kt:coil-compose:2.2.1"
 }
 

--- a/desktop-sample/build.gradle.kts
+++ b/desktop-sample/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 
 plugins {
   kotlin("jvm")
-  id("org.jetbrains.compose") version "1.2.0-alpha01-dev764"
+  id("org.jetbrains.compose") version Compose.desktopVersion
 }
 
 dependencies {

--- a/richtext-commonmark/build.gradle.kts
+++ b/richtext-commonmark/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("richtext-kmp-library")
-  id("org.jetbrains.compose") version "1.2.0-alpha01-dev764"
+  id("org.jetbrains.compose") version Compose.desktopVersion
   id("org.jetbrains.dokka")
 }
 

--- a/richtext-ui-material/build.gradle.kts
+++ b/richtext-ui-material/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("richtext-kmp-library")
-  id("org.jetbrains.compose") version "1.2.0-alpha01-dev764"
+  id("org.jetbrains.compose") version Compose.desktopVersion
   id("org.jetbrains.dokka")
 }
 

--- a/richtext-ui-material3/build.gradle.kts
+++ b/richtext-ui-material3/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("richtext-kmp-library")
-  id("org.jetbrains.compose") version "1.2.0-alpha01-dev764"
+  id("org.jetbrains.compose") version Compose.desktopVersion
   id("org.jetbrains.dokka")
 }
 

--- a/richtext-ui/build.gradle.kts
+++ b/richtext-ui/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("richtext-kmp-library")
-  id("org.jetbrains.compose") version "1.2.0-alpha01-dev764"
+  id("org.jetbrains.compose") version Compose.desktopVersion
   id("org.jetbrains.dokka")
 }
 


### PR DESCRIPTION
Compose Multiplatform 1.2.0 was released yesterday: https://blog.jetbrains.com/kotlin/2022/10/compose-multiplatform-1-2-is-out/

The new release has no build-breaking changes from the alphas, and I've done a smoke test of both Android and Desktop sample apps, all seems good.