### PR TITLE
Support set picture fill max screen width, and support set call back when click picture

### DIFF
--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
@@ -44,6 +44,7 @@ import com.halilibo.richtext.ui.resolveDefaults
   var isWordWrapEnabled by remember { mutableStateOf(true) }
   var markdownParseOptions by remember { mutableStateOf(MarkdownParseOptions.Default) }
   var isAutolinkEnabled by remember { mutableStateOf(true) }
+  var isImgFillMaxWidth by remember { mutableStateOf(true) }
 
   LaunchedEffect(isWordWrapEnabled) {
     richTextStyle = richTextStyle.copy(
@@ -55,6 +56,11 @@ import com.halilibo.richtext.ui.resolveDefaults
   LaunchedEffect(isAutolinkEnabled) {
     markdownParseOptions = markdownParseOptions.copy(
       autolink = isAutolinkEnabled
+    )
+  }
+  LaunchedEffect(isImgFillMaxWidth) {
+    markdownParseOptions = markdownParseOptions.copy(
+      imgFillMaxWidth = isImgFillMaxWidth
     )
   }
 
@@ -91,6 +97,14 @@ import com.halilibo.richtext.ui.resolveDefaults
               label = "Autolink"
             )
 
+            CheckboxPreference(
+              onClick = {
+                isImgFillMaxWidth = !isImgFillMaxWidth
+              },
+              checked = isImgFillMaxWidth,
+              label = "Img Fill Max Width"
+            )
+
             RichTextStyleConfig(
               richTextStyle = richTextStyle,
               onChanged = { richTextStyle = it }
@@ -108,6 +122,9 @@ import com.halilibo.richtext.ui.resolveDefaults
                 content = sampleMarkdown,
                 markdownParseOptions = markdownParseOptions,
                 onLinkClicked = {
+                  Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
+                },
+                onImgClicked = {
                   Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
                 }
               )

--- a/richtext-commonmark/src/androidMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
+++ b/richtext-commonmark/src/androidMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
@@ -77,7 +77,16 @@ internal actual fun RemoteImage(
         } else {
           // if size is not defined at all, Coil fails to render the image
           // here, we give a default size for images until they are loaded.
-          Modifier.size(DEFAULT_IMAGE_SIZE)
+          if (isFillMaxWidth) {
+            // if here not provide a enough size for coil,
+            // it may loaded a very small image, such as DEFAULT_IMAGE_SIZE
+            with(density) {
+              Modifier.size(constraints.maxWidth.toDp())
+            }
+          }
+          else {
+            Modifier.size(DEFAULT_IMAGE_SIZE)
+          }
         }
       }
     }

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownParseOptions.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownParseOptions.kt
@@ -6,11 +6,13 @@ package com.halilibo.richtext.markdown
  * @param autolink Detect plain text links and turn them into Markdown links.
  */
 public data class MarkdownParseOptions(
-  val autolink: Boolean
+  val autolink: Boolean,
+  val imgFillMaxWidth: Boolean
 ) {
   public companion object {
     public val Default: MarkdownParseOptions = MarkdownParseOptions(
-      autolink = true
+      autolink = true,
+      imgFillMaxWidth = false
     )
   }
 }

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
@@ -56,11 +56,12 @@ import com.halilibo.richtext.ui.string.withFormat
  * @param astNode Root node to accept as Text Content container.
  */
 @Composable
-internal fun RichTextScope.MarkdownRichText(astNode: AstNode, modifier: Modifier = Modifier) {
+internal fun RichTextScope.MarkdownRichText(astNode: AstNode, options: MarkdownParseOptions, modifier: Modifier = Modifier) {
   val onLinkClicked = LocalOnLinkClicked.current
+  val onImgClicked = LocalOnImgClicked.current
   // Assume that only RichText nodes reside below this level.
-  val richText = remember(astNode, onLinkClicked) {
-    computeRichTextString(astNode, onLinkClicked)
+  val richText = remember(astNode, onLinkClicked, onImgClicked) {
+    computeRichTextString(astNode, options, onLinkClicked, onImgClicked)
   }
 
   Text(text = richText, modifier = modifier)
@@ -68,7 +69,9 @@ internal fun RichTextScope.MarkdownRichText(astNode: AstNode, modifier: Modifier
 
 private fun computeRichTextString(
   astNode: AstNode,
-  onLinkClicked: (String) -> Unit
+  options: MarkdownParseOptions,
+  onLinkClicked: (String) -> Unit,
+  onImgClicked: ((String) -> Unit)?
 ): RichTextString {
   val richTextStringBuilder = RichTextString.Builder()
 
@@ -108,7 +111,9 @@ private fun computeRichTextString(
                 url = currentNodeType.destination,
                 contentDescription = currentNodeType.title,
                 modifier = Modifier.fillMaxWidth(),
-                contentScale = ContentScale.Inside
+                contentScale = if (options.imgFillMaxWidth) ContentScale.FillWidth else ContentScale.Inside,
+                isFillMaxWidth = options.imgFillMaxWidth,
+                onClickImg = onImgClicked
               )
             }
           )

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
@@ -14,5 +14,7 @@ internal expect fun RemoteImage(
   url: String,
   contentDescription: String?,
   modifier: Modifier = Modifier,
-  contentScale: ContentScale
+  contentScale: ContentScale,
+  isFillMaxWidth: Boolean,
+  onClickImg: ((url: String) -> Unit)?
 )

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/RenderTable.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/RenderTable.kt
@@ -10,7 +10,7 @@ import com.halilibo.richtext.ui.RichTextScope
 import com.halilibo.richtext.ui.Table
 
 @Composable
-internal fun RichTextScope.RenderTable(node: AstNode) {
+internal fun RichTextScope.RenderTable(node: AstNode, options: MarkdownParseOptions) {
   Table(
     headerRow = {
       node.filterChildrenType<AstTableHeader>()
@@ -20,7 +20,7 @@ internal fun RichTextScope.RenderTable(node: AstNode) {
         ?.filterChildrenType<AstTableCell>()
         ?.forEach { tableCell ->
           cell {
-            MarkdownRichText(tableCell)
+            MarkdownRichText(tableCell, options)
           }
         }
     }
@@ -33,7 +33,7 @@ internal fun RichTextScope.RenderTable(node: AstNode) {
           tableRow.filterChildrenType<AstTableCell>()
             .forEach { tableCell ->
               cell {
-                MarkdownRichText(tableCell)
+                MarkdownRichText(tableCell, options)
               }
             }
         }

--- a/richtext-commonmark/src/jvmMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
+++ b/richtext-commonmark/src/jvmMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
@@ -1,12 +1,14 @@
 package com.halilibo.richtext.markdown
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.toComposeImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import kotlinx.coroutines.Dispatchers
@@ -24,7 +26,9 @@ internal actual fun RemoteImage(
   url: String,
   contentDescription: String?,
   modifier: Modifier,
-  contentScale: ContentScale
+  contentScale: ContentScale,
+  isFillMaxWidth: Boolean,
+  onClickImg: ((url: String) -> Unit)?
 ) {
   val image by produceState<ImageBitmap?>(null, url) {
     loadFullImage(url)?.let {
@@ -33,10 +37,16 @@ internal actual fun RemoteImage(
   }
 
   if (image != null) {
+    val realModifier by remember(onClickImg, url) {
+      derivedStateOf {
+        if (onClickImg == null) modifier else modifier.clickable { onClickImg(url) }
+      }
+    }
+
     Image(
       bitmap = image!!,
       contentDescription = contentDescription,
-      modifier = modifier,
+      modifier = realModifier,
       contentScale = contentScale
     )
   }


### PR DESCRIPTION
From #108 #73 .

Add `imgFillMaxWidth: Boolean` to `MarkdownParseOptions`, which can make img fill parent's layout max width.

And add `onImgClicked: ((String) -> Unit)? = null` to `RichTextScope.Markdown`, which support call `onImgClicked(url)` when picture in MarkDown be clicked.