### PR TITLE
BugFix: Full-bleed markdown image fix

### DIFF
--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
@@ -153,6 +153,10 @@ private val sampleMarkdown = """
   ##### Header 5
   ###### Header 6
   ---
+  
+  ## Full-bleed Image
+  
+  ![](https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Image_created_with_a_mobile_phone.png/1920px-Image_created_with_a_mobile_phone.png)
 
   ## Emphasis
 

--- a/richtext-commonmark/src/androidMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
+++ b/richtext-commonmark/src/androidMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.unit.dp
 import coil.annotation.ExperimentalCoilApi
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
+import coil.size.Size
 
 private val DEFAULT_IMAGE_SIZE = 64.dp
 
@@ -33,6 +34,7 @@ internal actual fun RemoteImage(
   val painter = rememberAsyncImagePainter(
     ImageRequest.Builder(LocalContext.current)
       .data(data = url)
+      .size(Size.ORIGINAL)
       .crossfade(true)
       .build()
   )


### PR DESCRIPTION
Similar to #113, but without an option, since it seems that the correct way to display `![]()` images is with `fillwidth`

This PR forces Coil to request the picture's original size in order to correctly render images inside a markdown paragraph. 

| Before  | After |
| ------------- | ------------- |
| ![Screenshot_20230610-171926](https://github.com/halilozercan/compose-richtext/assets/532031/90eb71ee-4f31-47d2-9ea8-df0ba44c6107)  | ![Screenshot_20230610-171905](https://github.com/halilozercan/compose-richtext/assets/532031/1c8ceb9f-c900-4ff1-be90-b03f35ec29a7)  |