### PR TITLE
BugFix: Image goes over the text

### DIFF
--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
@@ -158,7 +158,7 @@ private val sampleMarkdown = """
   
   ![](https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Image_created_with_a_mobile_phone.png/1920px-Image_created_with_a_mobile_phone.png)
 
-  ## Images smaller than the width should center  
+  ## Images smaller than the width should center
   ![](https://cdn.nostr.build/p/4a84.png)
 
   ## Emphasis

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
@@ -158,6 +158,9 @@ private val sampleMarkdown = """
   
   ![](https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Image_created_with_a_mobile_phone.png/1920px-Image_created_with_a_mobile_phone.png)
 
+  ## Images smaller than the width should center  
+  ![](https://cdn.nostr.build/p/4a84.png)
+
   ## Emphasis
 
   Emphasis, aka italics, with *asterisks* or _underscores_.

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
@@ -106,7 +106,7 @@ import com.halilibo.richtext.ui.resolveDefaults
             ProvideTextStyle(TextStyle(lineHeight = 1.3.em)) {
               MaterialRichText(
                 style = richTextStyle,
-                //modifier = Modifier.padding(8.dp),
+                modifier = Modifier.padding(8.dp),
               ) {
                 Markdown(
                   content = sampleMarkdown,

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Card
 import androidx.compose.material.Checkbox
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ProvideTextStyle
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.darkColors
@@ -25,8 +26,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
 import com.halilibo.richtext.markdown.Markdown
 import com.halilibo.richtext.markdown.MarkdownParseOptions
 import com.halilibo.richtext.ui.RichTextStyle
@@ -100,17 +103,19 @@ import com.halilibo.richtext.ui.resolveDefaults
 
         SelectionContainer {
           Column(Modifier.verticalScroll(rememberScrollState())) {
-            MaterialRichText(
-              style = richTextStyle,
-              modifier = Modifier.padding(8.dp),
-            ) {
-              Markdown(
-                content = sampleMarkdown,
-                markdownParseOptions = markdownParseOptions,
-                onLinkClicked = {
-                  Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
-                }
-              )
+            ProvideTextStyle(TextStyle(lineHeight = 1.3.em)) {
+              MaterialRichText(
+                style = richTextStyle,
+                //modifier = Modifier.padding(8.dp),
+              ) {
+                Markdown(
+                  content = sampleMarkdown,
+                  markdownParseOptions = markdownParseOptions,
+                  onLinkClicked = {
+                    Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
+                  }
+                )
+              }
             }
           }
         }
@@ -168,6 +173,12 @@ private val sampleMarkdown = """
   Strong emphasis, aka bold, with **asterisks** or __underscores__.
 
   Combined emphasis with **asterisks and _underscores_**.
+  
+  ## Product Development
+  Most products are super close to alpha release. It’s going to be like popcorn soon.
+
+  Here’s a sneak peek with the Bitcoin Knowledge Project (name is still in progress):
+  ![](https://cdn.nostr.build/p/PxZ0.jpg)
 
   ---
 

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
@@ -165,7 +165,7 @@ private val sampleMarkdown = """
   ## Images smaller than the width should center
   ![](https://cdn.nostr.build/p/4a84.png)
   
-  ## On LineHeight bug, the image below goes over this text. 
+  On LineHeight bug, the image below goes over this text. 
   ![](https://cdn.nostr.build/p/PxZ0.jpg)
 
   ## Emphasis

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
@@ -160,11 +160,13 @@ private val sampleMarkdown = """
   ---
   
   ## Full-bleed Image
-  
   ![](https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Image_created_with_a_mobile_phone.png/1920px-Image_created_with_a_mobile_phone.png)
 
   ## Images smaller than the width should center
   ![](https://cdn.nostr.build/p/4a84.png)
+  
+  ## On LineHeight bug, the image below goes over this text. 
+  ![](https://cdn.nostr.build/p/PxZ0.jpg)
 
   ## Emphasis
 
@@ -173,12 +175,6 @@ private val sampleMarkdown = """
   Strong emphasis, aka bold, with **asterisks** or __underscores__.
 
   Combined emphasis with **asterisks and _underscores_**.
-  
-  ## Product Development
-  Most products are super close to alpha release. It’s going to be like popcorn soon.
-
-  Here’s a sneak peek with the Bitcoin Knowledge Project (name is still in progress):
-  ![](https://cdn.nostr.build/p/PxZ0.jpg)
 
   ---
 

--- a/desktop-sample/src/main/kotlin/com/halilibo/richtext/desktop/Main.kt
+++ b/desktop-sample/src/main/kotlin/com/halilibo/richtext/desktop/Main.kt
@@ -189,6 +189,9 @@ private val sampleMarkdown = """
   ## Images smaller than the width should center
   ![](https://cdn.nostr.build/p/4a84.png)
 
+  ## On LineHeight bug, the image below goes over this text. 
+  ![](https://cdn.nostr.build/p/PxZ0.jpg)
+
   ---
 
   ## Emphasis
@@ -198,27 +201,6 @@ private val sampleMarkdown = """
   Strong emphasis, aka bold, with **asterisks** or __underscores__.
 
   Combined emphasis with **asterisks and _underscores_**.
-
-  ## Product Development
-  Most products are super close to alpha release. It’s going to be like popcorn soon.
-
-  Here’s a sneak peek with the Bitcoin Knowledge Project (name is still in progress):
-  ![](https://cdn.nostr.build/p/PxZ0.jpg)
-
-  # Lifestuff
-  * Been helping Brittany a bunch to prepare [Bolli Imports](https://www.bollibears.com/) for [Shambhala](https://www.youtube.com/watch?v=UPQv2G0AMHo)
-  ![](https://cdn.nostr.build/p/Wgdk.webp)
-
-  * Went camping in Alberta’s crownland. We’re so far north that could still see the silhouette outline of the mountains at midnight. (Image not at midnight lol). Did a bunch of cold dips in the ice cold creek.
-  ![](https://cdn.nostr.build/p/6KZ2.webp)
-
-  Image [link](nostr:note13aleezg5xkmqskshlkh5nnzh243xfjchq52acfqxghe7pws2e9lsx5rxzz)
-
-  * Hit up the Calgary Stampede. Ate nasty food. Saw big majestic horses.
-  ![](https://cdn.nostr.build/p/BmZ0.webp)
-
-  * Wrote part of this with my feet in a bucket of ice water. This one hurt life hell for some reason. Usually not this bad.
-  ![](https://cdn.nostr.build/p/QEwP.webp)
 
   ---
 

--- a/desktop-sample/src/main/kotlin/com/halilibo/richtext/desktop/Main.kt
+++ b/desktop-sample/src/main/kotlin/com/halilibo/richtext/desktop/Main.kt
@@ -189,7 +189,7 @@ private val sampleMarkdown = """
   ## Images smaller than the width should center
   ![](https://cdn.nostr.build/p/4a84.png)
 
-  ## On LineHeight bug, the image below goes over this text. 
+  On LineHeight bug, the image below goes over this text. 
   ![](https://cdn.nostr.build/p/PxZ0.jpg)
 
   ---

--- a/desktop-sample/src/main/kotlin/com/halilibo/richtext/desktop/Main.kt
+++ b/desktop-sample/src/main/kotlin/com/halilibo/richtext/desktop/Main.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.ProvideTextStyle
 import androidx.compose.material.Slider
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
@@ -26,8 +27,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.singleWindowApplication
 import com.halilibo.richtext.markdown.Markdown
@@ -76,13 +79,15 @@ fun main(): Unit = singleWindowApplication(
                 .padding(8.dp)
             )
           }
-          MaterialRichText(
-            modifier = Modifier
-              .weight(1f)
-              .verticalScroll(rememberScrollState()),
-            style = richTextStyle
-          ) {
-            Markdown(content = text)
+          ProvideTextStyle(TextStyle(lineHeight = 1.3.em)) {
+            MaterialRichText(
+              modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState()),
+              style = richTextStyle
+            ) {
+              Markdown(content = text)
+            }
           }
         }
       }
@@ -193,6 +198,27 @@ private val sampleMarkdown = """
   Strong emphasis, aka bold, with **asterisks** or __underscores__.
 
   Combined emphasis with **asterisks and _underscores_**.
+
+  ## Product Development
+  Most products are super close to alpha release. It’s going to be like popcorn soon.
+
+  Here’s a sneak peek with the Bitcoin Knowledge Project (name is still in progress):
+  ![](https://cdn.nostr.build/p/PxZ0.jpg)
+
+  # Lifestuff
+  * Been helping Brittany a bunch to prepare [Bolli Imports](https://www.bollibears.com/) for [Shambhala](https://www.youtube.com/watch?v=UPQv2G0AMHo)
+  ![](https://cdn.nostr.build/p/Wgdk.webp)
+
+  * Went camping in Alberta’s crownland. We’re so far north that could still see the silhouette outline of the mountains at midnight. (Image not at midnight lol). Did a bunch of cold dips in the ice cold creek.
+  ![](https://cdn.nostr.build/p/6KZ2.webp)
+
+  Image [link](nostr:note13aleezg5xkmqskshlkh5nnzh243xfjchq52acfqxghe7pws2e9lsx5rxzz)
+
+  * Hit up the Calgary Stampede. Ate nasty food. Saw big majestic horses.
+  ![](https://cdn.nostr.build/p/BmZ0.webp)
+
+  * Wrote part of this with my feet in a bucket of ice water. This one hurt life hell for some reason. Usually not this bad.
+  ![](https://cdn.nostr.build/p/QEwP.webp)
 
   ---
 

--- a/desktop-sample/src/main/kotlin/com/halilibo/richtext/desktop/Main.kt
+++ b/desktop-sample/src/main/kotlin/com/halilibo/richtext/desktop/Main.kt
@@ -181,7 +181,7 @@ private val sampleMarkdown = """
   
   ![](https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Image_created_with_a_mobile_phone.png/1920px-Image_created_with_a_mobile_phone.png)
   
-  ## Images smaller than the width should center  
+  ## Images smaller than the width should center
   ![](https://cdn.nostr.build/p/4a84.png)
 
   ---

--- a/desktop-sample/src/main/kotlin/com/halilibo/richtext/desktop/Main.kt
+++ b/desktop-sample/src/main/kotlin/com/halilibo/richtext/desktop/Main.kt
@@ -177,6 +177,15 @@ private val sampleMarkdown = """
   ###### Header 6
   ---
 
+  ## Full-bleed Image
+  
+  ![](https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Image_created_with_a_mobile_phone.png/1920px-Image_created_with_a_mobile_phone.png)
+  
+  ## Images smaller than the width should center  
+  ![](https://cdn.nostr.build/p/4a84.png)
+
+  ---
+
   ## Emphasis
 
   Emphasis, aka italics, with *asterisks* or _underscores_.

--- a/richtext-commonmark/src/androidMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
+++ b/richtext-commonmark/src/androidMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
@@ -41,7 +41,7 @@ internal actual fun RemoteImage(
 
   val density = LocalDensity.current
 
-  BoxWithConstraints {
+  BoxWithConstraints(modifier, contentAlignment = Alignment.Center) {
     val sizeModifier by remember(density, painter) {
       derivedStateOf {
         val painterIntrinsicSize = painter.state.painter?.intrinsicSize

--- a/richtext-commonmark/src/androidMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
+++ b/richtext-commonmark/src/androidMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
@@ -43,34 +43,30 @@ internal actual fun RemoteImage(
   val density = LocalDensity.current
 
   BoxWithConstraints(modifier, contentAlignment = Alignment.Center) {
-    val sizeModifier by remember(density, painter.state) {
-      derivedStateOf {
-        val painterIntrinsicSize = painter.state.painter?.intrinsicSize
-        if (painterIntrinsicSize != null &&
-          painterIntrinsicSize.isSpecified &&
-          painterIntrinsicSize.width != Float.POSITIVE_INFINITY &&
-          painterIntrinsicSize.height != Float.POSITIVE_INFINITY
-        ) {
-          val width = painterIntrinsicSize.width
-          val height = painterIntrinsicSize.height
-          val scale = if (width > constraints.maxWidth) {
-            constraints.maxWidth.toFloat() / width
-          } else {
-            1f
-          }
-
-          with(density) {
-            Modifier.size(
-              (width * scale).toDp(),
-              (height * scale).toDp()
-            )
-          }
-        } else {
-          // if size is not defined at all, Coil fails to render the image
-          // here, we give a default size for images until they are loaded.
-          Modifier.size(DEFAULT_IMAGE_SIZE)
-        }
+    val painterIntrinsicSize = painter.state.painter?.intrinsicSize
+    val sizeModifier = if (painterIntrinsicSize != null &&
+      painterIntrinsicSize.isSpecified &&
+      painterIntrinsicSize.width != Float.POSITIVE_INFINITY &&
+      painterIntrinsicSize.height != Float.POSITIVE_INFINITY
+    ) {
+      val width = painterIntrinsicSize.width
+      val height = painterIntrinsicSize.height
+      val scale = if (width > constraints.maxWidth) {
+        constraints.maxWidth.toFloat() / width
+      } else {
+        1f
       }
+
+      with(density) {
+        Modifier.size(
+          (width * scale).toDp(),
+          (height * scale).toDp()
+        )
+      }
+    } else {
+      // if size is not defined at all, Coil fails to render the image
+      // here, we give a default size for images until they are loaded.
+      Modifier.size(DEFAULT_IMAGE_SIZE)
     }
 
     Image(

--- a/richtext-commonmark/src/androidMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
+++ b/richtext-commonmark/src/androidMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
@@ -43,7 +43,7 @@ internal actual fun RemoteImage(
   val density = LocalDensity.current
 
   BoxWithConstraints(modifier, contentAlignment = Alignment.Center) {
-    val sizeModifier by remember(density, painter, painter.state) {
+    val sizeModifier by remember(density, painter.state) {
       derivedStateOf {
         val painterIntrinsicSize = painter.state.painter?.intrinsicSize
         if (painterIntrinsicSize != null &&

--- a/richtext-commonmark/src/androidMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
+++ b/richtext-commonmark/src/androidMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
-import coil.annotation.ExperimentalCoilApi
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
 import coil.size.Size
@@ -24,7 +23,6 @@ private val DEFAULT_IMAGE_SIZE = 64.dp
 /**
  * Implementation of RemoteImage by using Coil library for Android.
  */
-@OptIn(ExperimentalCoilApi::class)
 @Composable
 internal actual fun RemoteImage(
   url: String,
@@ -59,6 +57,8 @@ internal actual fun RemoteImage(
             1f
           }
 
+          println("AAA ${height * scale} ${width * scale}")
+
           with(density) {
             Modifier.size(
               (width * scale).toDp(),
@@ -72,6 +72,8 @@ internal actual fun RemoteImage(
         }
       }
     }
+
+    println("AAA ${constraints.minHeight} ${constraints.maxHeight}")
 
     Image(
       painter = painter,

--- a/richtext-commonmark/src/androidMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
+++ b/richtext-commonmark/src/androidMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
@@ -43,30 +43,34 @@ internal actual fun RemoteImage(
   val density = LocalDensity.current
 
   BoxWithConstraints(modifier, contentAlignment = Alignment.Center) {
-    val painterIntrinsicSize = painter.state.painter?.intrinsicSize
-    val sizeModifier = if (painterIntrinsicSize != null &&
-      painterIntrinsicSize.isSpecified &&
-      painterIntrinsicSize.width != Float.POSITIVE_INFINITY &&
-      painterIntrinsicSize.height != Float.POSITIVE_INFINITY
-    ) {
-      val width = painterIntrinsicSize.width
-      val height = painterIntrinsicSize.height
-      val scale = if (width > constraints.maxWidth) {
-        constraints.maxWidth.toFloat() / width
-      } else {
-        1f
-      }
+    val sizeModifier by remember(density, painter) {
+      derivedStateOf {
+        val painterIntrinsicSize = painter.state.painter?.intrinsicSize
+        if (painterIntrinsicSize != null &&
+          painterIntrinsicSize.isSpecified &&
+          painterIntrinsicSize.width != Float.POSITIVE_INFINITY &&
+          painterIntrinsicSize.height != Float.POSITIVE_INFINITY
+        ) {
+          val width = painterIntrinsicSize.width
+          val height = painterIntrinsicSize.height
+          val scale = if (width > constraints.maxWidth) {
+            constraints.maxWidth.toFloat() / width
+          } else {
+            1f
+          }
 
-      with(density) {
-        Modifier.size(
-          (width * scale).toDp(),
-          (height * scale).toDp()
-        )
+          with(density) {
+            Modifier.size(
+              (width * scale).toDp(),
+              (height * scale).toDp()
+            )
+          }
+        } else {
+          // if size is not defined at all, Coil fails to render the image
+          // here, we give a default size for images until they are loaded.
+          Modifier.size(DEFAULT_IMAGE_SIZE)
+        }
       }
-    } else {
-      // if size is not defined at all, Coil fails to render the image
-      // here, we give a default size for images until they are loaded.
-      Modifier.size(DEFAULT_IMAGE_SIZE)
     }
 
     Image(

--- a/richtext-commonmark/src/androidMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
+++ b/richtext-commonmark/src/androidMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.isSpecified
 import androidx.compose.ui.layout.ContentScale

--- a/richtext-commonmark/src/androidMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
+++ b/richtext-commonmark/src/androidMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
@@ -57,8 +57,6 @@ internal actual fun RemoteImage(
             1f
           }
 
-          println("AAA ${height * scale} ${width * scale}")
-
           with(density) {
             Modifier.size(
               (width * scale).toDp(),
@@ -72,8 +70,6 @@ internal actual fun RemoteImage(
         }
       }
     }
-
-    println("AAA ${constraints.minHeight} ${constraints.maxHeight}")
 
     Image(
       painter = painter,

--- a/richtext-commonmark/src/androidMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
+++ b/richtext-commonmark/src/androidMain/kotlin/com/halilibo/richtext/markdown/RemoteImage.kt
@@ -43,7 +43,7 @@ internal actual fun RemoteImage(
   val density = LocalDensity.current
 
   BoxWithConstraints(modifier, contentAlignment = Alignment.Center) {
-    val sizeModifier by remember(density, painter) {
+    val sizeModifier by remember(density, painter, painter.state) {
       derivedStateOf {
         val painterIntrinsicSize = painter.state.painter?.intrinsicSize
         if (painterIntrinsicSize != null &&

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/RichTextString.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/RichTextString.kt
@@ -302,7 +302,9 @@ public data class RichTextString internal constructor(
       // This is important for inline content because the user might set a global line height
       // via ProvideTextStyle(TextStyle(lineHeight = 1.3.em)) { ... }
       // Once set, the line height is fixed for all objects and any inline content (like images)
-      // will expand over the text. Since this is not a text section, it should be fine. 
+      // will expand over the text. Since this is not a text section, it should be fine.
+      //
+      // Fixed line height seems to only affect mobile.
       builder.pushStyle(ParagraphStyle())
       builder.appendInlineContent(tag, alternateText)
       builder.pop()

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/RichTextString.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/RichTextString.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.ParagraphStyle
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
@@ -295,7 +296,16 @@ public data class RichTextString internal constructor(
     ) {
       val tag = randomUUID()
       formatObjects["inline:$tag"] = content
+
+      // Resets the style to defaults.
+      //
+      // This is important for inline content because the user might set a global line height
+      // via ProvideTextStyle(TextStyle(lineHeight = 1.3.em)) { ... }
+      // Once set, the line height is fixed for all objects and any inline content (like images)
+      // will expand over the text. Since this is not a text section, it should be fine. 
+      builder.pushStyle(ParagraphStyle())
       builder.appendInlineContent(tag, alternateText)
+      builder.pop()
     }
 
     /**


### PR DESCRIPTION
When users set a lineHeight via `ProvideTextStyle(TextStyle(lineHeight = 1.3.em)) { ... }`, the Markdown renderer forces that height to be true in all cases, even for inline Images. This PR resets the style to a regular markdown Paragraph just for the Image portion of the text. 