### PR TITLE
Option to use parsed Markdown

### DIFF
--- a/richtext-commonmark/build.gradle.kts
+++ b/richtext-commonmark/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
       dependencies {
         implementation(compose.runtime)
         implementation(compose.foundation)
+        api(Commonmark.core)
         api(project(":richtext-ui"))
       }
     }
@@ -28,7 +29,6 @@ kotlin {
       dependencies {
         implementation(Compose.coil)
 
-        implementation(Commonmark.core)
         implementation(Commonmark.tables)
         implementation(Commonmark.strikethrough)
         implementation(Commonmark.autolink)
@@ -41,7 +41,6 @@ kotlin {
         implementation(compose.desktop.currentOs)
         implementation(Network.okHttp)
 
-        implementation(Commonmark.core)
         implementation(Commonmark.tables)
         implementation(Commonmark.strikethrough)
         implementation(Commonmark.autolink)

--- a/richtext-commonmark/src/commonJvmAndroid/kotlin/com/halilibo/richtext/markdown/AstNodeConvert.kt
+++ b/richtext-commonmark/src/commonJvmAndroid/kotlin/com/halilibo/richtext/markdown/AstNodeConvert.kt
@@ -186,10 +186,10 @@ internal fun convert(
   return newNode
 }
 
-internal fun Node.convert() = convert(this)
+internal actual fun Node.toAstNode() = convert(this)
 
 @Composable
-internal actual fun parsedMarkdownAst(text: String, options: MarkdownParseOptions): AstNode? {
+internal actual fun parsedMarkdown(text: String, options: MarkdownParseOptions): Node? {
   val parser = remember(options) {
     Parser.builder()
       .extensions(
@@ -202,10 +202,9 @@ internal actual fun parsedMarkdownAst(text: String, options: MarkdownParseOption
       .build()
   }
 
-  val astRootNode by produceState<AstNode?>(null, text, parser) {
-    value = parser.parse(text).convert()
+  val rootNode by produceState<Node?>(null, text, parser) {
+    value = parser.parse(text)
   }
 
-  return astRootNode
+  return rootNode
 }
-

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/Markdown.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/Markdown.kt
@@ -40,6 +40,7 @@ import com.halilibo.richtext.ui.RichTextScope
 import com.halilibo.richtext.ui.string.InlineContent
 import com.halilibo.richtext.ui.string.Text
 import com.halilibo.richtext.ui.string.richTextString
+import org.commonmark.node.Node
 
 /**
  * A composable that renders Markdown content using RichText.
@@ -54,6 +55,21 @@ public fun RichTextScope.Markdown(
   markdownParseOptions: MarkdownParseOptions = MarkdownParseOptions.Default,
   onLinkClicked: ((String) -> Unit)? = null
 ) {
+  val markdown = parsedMarkdown(text = content, options = markdownParseOptions)
+  markdown?.let { Markdown(it, onLinkClicked) }
+}
+
+/**
+ * A composable that renders Markdown node using RichText.
+ *
+ * @param content CommonMark node to render.
+ * @param onLinkClicked A function to invoke when a link is clicked from rendered content.
+ */
+@Composable
+public fun RichTextScope.Markdown(
+  content: Node,
+  onLinkClicked: ((String) -> Unit)? = null
+) {
   val onLinkClickedState = rememberUpdatedState(onLinkClicked)
   // Can't use UriHandlerAmbient.current::openUri here,
   // see https://issuetracker.google.com/issues/172366483
@@ -63,10 +79,15 @@ public fun RichTextScope.Markdown(
     }
   }
   CompositionLocalProvider(LocalOnLinkClicked provides realLinkClickedHandler) {
-    val markdownAst = parsedMarkdownAst(text = content, options = markdownParseOptions)
-    RecursiveRenderMarkdownAst(astNode = markdownAst)
+    RecursiveRenderMarkdownAst(astNode = content.toAstNode())
   }
 }
+
+/**
+ * Convert CommonMark [Node] to [AstNode].
+ */
+@Composable
+internal expect fun Node.toAstNode(): AstNode?
 
 /**
  * Parse markdown content and return Abstract Syntax Tree(AST).
@@ -76,7 +97,7 @@ public fun RichTextScope.Markdown(
  * @param options Options for the Markdown parser.
  */
 @Composable
-internal expect fun parsedMarkdownAst(text: String, options: MarkdownParseOptions): AstNode?
+internal expect fun parsedMarkdown(text: String, options: MarkdownParseOptions): Node?
 
 /**
  * When parsed, markdown content or any other rich text can be represented as a tree.


### PR DESCRIPTION
Currently the library parses markdown internally, but there are several issues with it:
- The parsing is asynchronous without any callbacks, which causes many problems. For example, it's not possible to scroll the list with markdown items to the right position because in the initial state all items are zero height
- It's not possible to do parsing and related logic in the view model or data layer
- It's not possible to support custom nodes (this is something we want to contribute later as well)

This PR adds an overload for `Markdown` composable that takes Commonmark `Node` object.

One drawback is that we need to expose Commonmark as an API dependency because public API now uses it, but feel like it should be ok considering that the module is called `richtext-commonmark`.