### PR TITLE
Pass `astNodeType.startNumber` as `startIndex`

### DIFF
--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
@@ -195,6 +195,16 @@ private val sampleMarkdown = """
   * Unordered list can use asterisks
   - Or minuses
   + Or pluses
+<!-- -->
+  2. Ordered list starting with `2.`
+  3. Another item
+<!-- -->
+  0. Ordered list starting with `0.`
+<!-- -->
+  003. Ordered list starting with `003.`
+<!-- -->
+  -1. Starting with `-1.` should not be list
+
 
   ---
 

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/Markdown.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/markdown/Markdown.kt
@@ -126,7 +126,8 @@ internal fun RichTextScope.RecursiveRenderMarkdownAst(astNode: AstNode?) {
     is AstOrderedList -> {
       FormattedList(
         listType = Ordered,
-        items = astNode.childrenSequence().toList()
+        items = astNode.childrenSequence().toList(),
+        startIndex = astNodeType.startNumber - 1,
       ) { astListItem ->
         visitChildren(astListItem)
       }

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
@@ -184,7 +184,7 @@ private val LocalListLevel = compositionLocalOf { 0 }
 @Composable public inline fun RichTextScope.FormattedList(
   listType: ListType,
   vararg children: @Composable RichTextScope.() -> Unit
-): Unit = FormattedList(listType, children.asList()) { it() }
+): Unit = FormattedList(listType, children.asList(), 0) { it() }
 
 /**
  * Creates a formatted list such as a bullet list or numbered list.
@@ -195,6 +195,7 @@ private val LocalListLevel = compositionLocalOf { 0 }
 @Composable public fun <T> RichTextScope.FormattedList(
   listType: ListType,
   items: List<T>,
+  startIndex: Int = 0,
   drawItem: @Composable RichTextScope.(T) -> Unit
 ) {
   val listStyle = currentRichTextStyle.resolveDefaults().listStyle!!
@@ -210,7 +211,7 @@ private val LocalListLevel = compositionLocalOf { 0 }
     prefixPadding = PaddingValues(start = markerIndent, end = contentsIndent),
     prefixForIndex = { index ->
       when (listType) {
-        Ordered -> listStyle.orderedMarkers!!().drawMarker(currentLevel, index)
+        Ordered -> listStyle.orderedMarkers!!().drawMarker(currentLevel, startIndex + index)
         Unordered -> listStyle.unorderedMarkers!!().drawMarker(currentLevel)
       }
     },


### PR DESCRIPTION
This fixes the start number of the markdown list. Markdown can start with any number except -ve numbers. Rest numbers are discarded

This fixes https://github.com/halilozercan/compose-richtext/issues/112