### PR TITLE
Revert LineHeight bug fix

### DIFF
--- a/android-sample/build.gradle.kts
+++ b/android-sample/build.gradle.kts
@@ -33,12 +33,12 @@ android {
 dependencies {
   implementation(project(":printing"))
   implementation(project(":richtext-commonmark"))
-  implementation(project(":richtext-ui-material"))
+  implementation(project(":richtext-ui-material3"))
   implementation(project(":slideshow"))
   implementation(AndroidX.appcompat)
   implementation(Compose.activity)
   implementation(compose.foundation)
   implementation(compose.materialIconsExtended)
-  implementation(compose.material)
+  implementation(compose.material3)
   implementation(compose.uiTooling)
 }

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/Demo.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/Demo.kt
@@ -7,8 +7,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.LocalContentColor
-import androidx.compose.material.Text
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
@@ -28,7 +28,7 @@ import com.halilibo.richtext.ui.ListType.Unordered
 import com.halilibo.richtext.ui.RichTextScope
 import com.halilibo.richtext.ui.RichTextStyle
 import com.halilibo.richtext.ui.Table
-import com.halilibo.richtext.ui.material.RichText
+import com.halilibo.richtext.ui.material3.RichText
 
 @Preview(widthDp = 300, heightDp = 1000)
 @Composable fun RichTextDemoOnWhite() {

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/DocumentSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/DocumentSample.kt
@@ -18,17 +18,17 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Icon
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.OutlinedButton
-import androidx.compose.material.ProvideTextStyle
-import androidx.compose.material.Text
-import androidx.compose.material.TextButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Email
 import androidx.compose.material.icons.outlined.Phone
 import androidx.compose.material.icons.outlined.Print
-import androidx.compose.material.lightColors
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -54,7 +54,7 @@ import androidx.compose.ui.unit.offset
 import androidx.compose.ui.unit.sp
 import com.halilibo.richtext.ui.FormattedList
 import com.halilibo.richtext.ui.ListType.Unordered
-import com.halilibo.richtext.ui.material.RichText
+import com.halilibo.richtext.ui.material3.RichText
 import com.zachklipp.richtext.ui.printing.Printable
 import com.zachklipp.richtext.ui.printing.PrintableController
 import com.zachklipp.richtext.ui.printing.hideWhenPrinting
@@ -190,8 +190,8 @@ private val LargeGap = 96.dp
         Dp.Infinity to LargeGap
       )
     ) {
-      MaterialTheme(
-        colors = lightColors(
+      SampleTheme(
+        colorScheme = lightColorScheme(
           primary = Color.Black,
           secondary = Color(0x20, 0x79, 0xc7)
         )
@@ -205,7 +205,7 @@ private val LargeGap = 96.dp
 @Composable private fun Title(text: String) {
   Text(
     text,
-    style = MaterialTheme.typography.h3,
+    style = MaterialTheme.typography.headlineMedium,
     fontFamily = FontFamily.Serif,
     fontWeight = Bold
   )
@@ -247,7 +247,7 @@ private val LargeGap = 96.dp
       uppercaseTitle,
       color = Color(0x20, 0x79, 0xc7),
       fontWeight = Bold,
-      style = MaterialTheme.typography.caption,
+      style = MaterialTheme.typography.labelMedium,
       modifier = Modifier
         .keepOnPageWithNext()
         .padding(top = 32.dp, bottom = 8.dp)

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/LazyMarkdownSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/LazyMarkdownSample.kt
@@ -10,14 +10,13 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.selection.SelectionContainer
-import androidx.compose.material.Card
-import androidx.compose.material.Checkbox
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.ProvideTextStyle
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
-import androidx.compose.material.darkColors
-import androidx.compose.material.lightColors
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -28,10 +27,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.em
 import com.halilibo.richtext.commonmark.CommonmarkAstNodeParser
 import com.halilibo.richtext.commonmark.MarkdownParseOptions
 import com.halilibo.richtext.markdown.BasicMarkdown
@@ -40,7 +37,7 @@ import com.halilibo.richtext.markdown.node.AstNode
 import com.halilibo.richtext.ui.RichTextScope
 import com.halilibo.richtext.ui.RichTextStyle
 import com.halilibo.richtext.ui.currentRichTextStyle
-import com.halilibo.richtext.ui.material.RichText
+import com.halilibo.richtext.ui.material3.RichText
 import com.halilibo.richtext.ui.resolveDefaults
 
 @Preview
@@ -69,14 +66,14 @@ import com.halilibo.richtext.ui.resolveDefaults
     )
   }
 
-  val colors = if (isDarkModeEnabled) darkColors() else lightColors()
+  val colors = if (isDarkModeEnabled) darkColorScheme() else lightColorScheme()
   val context = LocalContext.current
 
-  MaterialTheme(colors = colors) {
+  SampleTheme(colorScheme = colors) {
     Surface {
       Column {
         // Config
-        Card(elevation = 4.dp) {
+        Card(elevation = CardDefaults.elevatedCardElevation()) {
           Column {
             FlowRow {
               CheckboxPreference(
@@ -110,24 +107,22 @@ import com.halilibo.richtext.ui.resolveDefaults
         }
 
         SelectionContainer {
-          ProvideTextStyle(TextStyle(lineHeight = 1.3.em)) {
-            val parser = remember(markdownParseOptions) {
-              CommonmarkAstNodeParser(markdownParseOptions)
-            }
+          val parser = remember(markdownParseOptions) {
+            CommonmarkAstNodeParser(markdownParseOptions)
+          }
 
-            val astNode = remember(parser) {
-              parser.parse(sampleMarkdown)
-            }
+          val astNode = remember(parser) {
+            parser.parse(sampleMarkdown)
+          }
 
-            RichText(
-              style = richTextStyle,
-              linkClickHandler = {
-                Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
-              },
-              modifier = Modifier.padding(8.dp),
-            ) {
-              LazyMarkdown(astNode)
-            }
+          RichText(
+            style = richTextStyle,
+            linkClickHandler = {
+              Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
+            },
+            modifier = Modifier.padding(8.dp),
+          ) {
+            LazyMarkdown(astNode)
           }
         }
       }

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
@@ -11,14 +11,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Card
-import androidx.compose.material.Checkbox
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.ProvideTextStyle
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
-import androidx.compose.material.darkColors
-import androidx.compose.material.lightColors
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -28,15 +27,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.em
 import com.halilibo.richtext.commonmark.CommonmarkAstNodeParser
 import com.halilibo.richtext.commonmark.MarkdownParseOptions
 import com.halilibo.richtext.markdown.BasicMarkdown
 import com.halilibo.richtext.ui.RichTextStyle
-import com.halilibo.richtext.ui.material.RichText
+import com.halilibo.richtext.ui.material3.RichText
 import com.halilibo.richtext.ui.resolveDefaults
 
 @Preview
@@ -65,14 +62,14 @@ import com.halilibo.richtext.ui.resolveDefaults
     )
   }
 
-  val colors = if (isDarkModeEnabled) darkColors() else lightColors()
+  val colors = if (isDarkModeEnabled) darkColorScheme() else lightColorScheme()
   val context = LocalContext.current
 
-  MaterialTheme(colors = colors) {
+  SampleTheme(colorScheme = colors) {
     Surface {
       Column {
         // Config
-        Card(elevation = 4.dp) {
+        Card(elevation = CardDefaults.elevatedCardElevation()) {
           Column {
             FlowRow {
               CheckboxPreference(
@@ -107,24 +104,22 @@ import com.halilibo.richtext.ui.resolveDefaults
 
         SelectionContainer {
           Column(Modifier.verticalScroll(rememberScrollState())) {
-            ProvideTextStyle(TextStyle(lineHeight = 1.3.em)) {
-              val parser = remember(markdownParseOptions) {
-                CommonmarkAstNodeParser(markdownParseOptions)
-              }
+            val parser = remember(markdownParseOptions) {
+              CommonmarkAstNodeParser(markdownParseOptions)
+            }
 
-              val astNode = remember(parser) {
-                parser.parse(sampleMarkdown)
-              }
+            val astNode = remember(parser) {
+              parser.parse(sampleMarkdown)
+            }
 
-              RichText(
-                style = richTextStyle,
-                linkClickHandler = {
-                  Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
-                },
-                modifier = Modifier.padding(8.dp),
-              ) {
-                BasicMarkdown(astNode)
-              }
+            RichText(
+              style = richTextStyle,
+              linkClickHandler = {
+                Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
+              },
+              modifier = Modifier.padding(8.dp),
+            ) {
+              BasicMarkdown(astNode)
             }
           }
         }

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/PagedSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/PagedSample.kt
@@ -5,10 +5,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Button
-import androidx.compose.material.Checkbox
-import androidx.compose.material.Text
-import androidx.compose.material.TextButton
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/RichTextSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/RichTextSample.kt
@@ -8,14 +8,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Card
-import androidx.compose.material.Checkbox
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Slider
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
-import androidx.compose.material.darkColors
-import androidx.compose.material.lightColors
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -38,13 +38,13 @@ import com.halilibo.richtext.ui.resolveDefaults
   var richTextStyle by remember { mutableStateOf(RichTextStyle().resolveDefaults()) }
   var isDarkModeEnabled by remember { mutableStateOf(false) }
 
-  val colors = if (isDarkModeEnabled) darkColors() else lightColors()
+  val colors = if (isDarkModeEnabled) darkColorScheme() else lightColorScheme()
 
-  MaterialTheme(colors = colors) {
+  SampleTheme(colorScheme = colors) {
     Surface {
       Column {
         // Config
-        Card(elevation = 4.dp) {
+        Card(elevation = CardDefaults.elevatedCardElevation()) {
           Column {
             Row(
               Modifier

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/SampleLauncher.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/SampleLauncher.kt
@@ -8,15 +8,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.ListItem
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Scaffold
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
-import androidx.compose.material.TopAppBar
-import androidx.compose.material.darkColors
-import androidx.compose.material.lightColors
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -56,9 +54,9 @@ private val Samples = listOf<Pair<String, @Composable () -> Unit>>(
   }
 }
 
-@OptIn(ExperimentalMaterialApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable private fun SamplesListScreen(onSampleClicked: (Int) -> Unit) {
-  MaterialTheme(colors = darkColors()) {
+  SampleTheme(colorScheme = darkColorScheme()) {
     Scaffold(
       topBar = {
         TopAppBar(title = { Text("Samples") })
@@ -67,11 +65,10 @@ private val Samples = listOf<Pair<String, @Composable () -> Unit>>(
       LazyColumn(modifier = Modifier.padding(contentPadding)) {
         itemsIndexed(Samples) { index, (title, sampleContent) ->
           ListItem(
-            Modifier.clickable(onClick = { onSampleClicked(index) }),
-            icon = { SamplePreview(sampleContent) }
-          ) {
-            Text(title)
-          }
+            headlineContent = { Text(title) },
+            modifier = Modifier.clickable(onClick = { onSampleClicked(index) }),
+            leadingContent = { SamplePreview(sampleContent) }
+          )
         }
       }
     }
@@ -90,7 +87,7 @@ private val Samples = listOf<Pair<String, @Composable () -> Unit>>(
         transformOrigin = TransformOrigin(0f, 0f)
       ),
   ) {
-    MaterialTheme(colors = lightColors()) {
+    SampleTheme(colorScheme = darkColorScheme()) {
       Surface(content = content)
     }
   }

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/SampleTheme.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/SampleTheme.kt
@@ -1,0 +1,25 @@
+package com.zachklipp.richtext.sample
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Shapes
+import androidx.compose.material3.Typography
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.unit.TextUnit
+
+@Composable
+fun SampleTheme(
+  colorScheme: ColorScheme = MaterialTheme.colorScheme,
+  shapes: Shapes = MaterialTheme.shapes,
+  typography: Typography = MaterialTheme.typography,
+  content: @Composable () -> Unit
+) {
+  MaterialTheme(colorScheme, shapes, typography) {
+    val textStyle = LocalTextStyle.current.copy(lineHeight = TextUnit.Unspecified)
+    CompositionLocalProvider(LocalTextStyle provides textStyle) {
+      content()
+    }
+  }
+}

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/SlideshowSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/SlideshowSample.kt
@@ -11,7 +11,7 @@ import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.SpanStyle
@@ -22,7 +22,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import com.halilibo.richtext.ui.FormattedList
 import com.halilibo.richtext.ui.ListType.Ordered
-import com.halilibo.richtext.ui.material.RichText
+import com.halilibo.richtext.ui.material3.RichText
 import com.zachklipp.richtext.ui.slideshow.BodySlide
 import com.zachklipp.richtext.ui.slideshow.NavigableContentContainer
 import com.zachklipp.richtext.ui.slideshow.SlideDivider

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/TextDemo.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/TextDemo.kt
@@ -12,7 +12,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -33,7 +33,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
-import com.halilibo.richtext.ui.material.RichText
+import com.halilibo.richtext.ui.material3.RichText
 import com.halilibo.richtext.ui.string.InlineContent
 import com.halilibo.richtext.ui.string.RichTextString.Builder
 import com.halilibo.richtext.ui.string.RichTextString.Format

--- a/desktop-sample/src/main/kotlin/com/halilibo/richtext/desktop/Main.kt
+++ b/desktop-sample/src/main/kotlin/com/halilibo/richtext/desktop/Main.kt
@@ -91,48 +91,46 @@ fun main(): Unit = singleWindowApplication(
                 .padding(8.dp)
             )
           }
-          ProvideTextStyle(TextStyle(lineHeight = 1.3.em)) {
-            var selectedTab by remember { mutableStateOf(0) }
-            Column(Modifier.weight(1f)) {
-              DisableSelection {
-                TabRow(selectedTab) {
-                  LeadingIconTab(
-                    selected = selectedTab == 0,
-                    onClick = { selectedTab = 0 },
-                    text = { Text("Normal") },
-                    icon = { Icon(Icons.Default.Info, "") })
-                  LeadingIconTab(
-                    selected = selectedTab == 1,
-                    onClick = { selectedTab = 1 },
-                    text = { Text("Lazy") },
-                    icon = { Icon(Icons.Default.Favorite, "") })
-                }
+          var selectedTab by remember { mutableStateOf(0) }
+          Column(Modifier.weight(1f)) {
+            DisableSelection {
+              TabRow(selectedTab) {
+                LeadingIconTab(
+                  selected = selectedTab == 0,
+                  onClick = { selectedTab = 0 },
+                  text = { Text("Normal") },
+                  icon = { Icon(Icons.Default.Info, "") })
+                LeadingIconTab(
+                  selected = selectedTab == 1,
+                  onClick = { selectedTab = 1 },
+                  text = { Text("Lazy") },
+                  icon = { Icon(Icons.Default.Favorite, "") })
               }
-              if (selectedTab == 0) {
-                RichText(
-                  modifier = Modifier.verticalScroll(rememberScrollState()),
-                  style = richTextStyle,
-                  linkClickHandler = {
-                    println("Link clicked destination=$it")
-                  }
-                ) {
-                  Markdown(content = text)
+            }
+            if (selectedTab == 0) {
+              RichText(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                style = richTextStyle,
+                linkClickHandler = {
+                  println("Link clicked destination=$it")
                 }
-              } else {
-                val parser = remember { CommonmarkAstNodeParser() }
+              ) {
+                Markdown(content = text)
+              }
+            } else {
+              val parser = remember { CommonmarkAstNodeParser() }
 
-                val astNode = remember(parser) {
-                  parser.parse(sampleMarkdown)
-                }
+              val astNode = remember(parser) {
+                parser.parse(sampleMarkdown)
+              }
 
-                RichText(
-                  style = richTextStyle,
-                  linkClickHandler = {
-                    println("Link clicked destination=$it")
-                  }
-                ) {
-                  LazyMarkdown(astNode)
+              RichText(
+                style = richTextStyle,
+                linkClickHandler = {
+                  println("Link clicked destination=$it")
                 }
+              ) {
+                LazyMarkdown(astNode)
               }
             }
           }

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/RichTextThemeConfiguration.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/RichTextThemeConfiguration.kt
@@ -25,7 +25,11 @@ internal data class RichTextThemeConfiguration(
       content()
     }
   }
-)
+) {
+  companion object {
+    internal val Default = RichTextThemeConfiguration()
+  }
+}
 
 internal val LocalRichTextThemeConfiguration: ProvidableCompositionLocal<RichTextThemeConfiguration> =
   compositionLocalOf { RichTextThemeConfiguration() }

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/RichTextThemeProvider.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/RichTextThemeProvider.kt
@@ -33,18 +33,17 @@ public fun RichTextThemeProvider(
   contentColorBackProvider: @Composable ((Color, @Composable () -> Unit) -> Unit)? = null,
   content: @Composable () -> Unit
 ) {
-  val defaultRichTextThemeConfiguration = RichTextThemeConfiguration()
   CompositionLocalProvider(
     LocalRichTextThemeConfiguration provides
         RichTextThemeConfiguration(
           textStyleProvider = textStyleProvider
-            ?: defaultRichTextThemeConfiguration.textStyleProvider,
+            ?: RichTextThemeConfiguration.Default.textStyleProvider,
           textStyleBackProvider = textStyleBackProvider
-            ?: defaultRichTextThemeConfiguration.textStyleBackProvider,
+            ?: RichTextThemeConfiguration.Default.textStyleBackProvider,
           contentColorProvider = contentColorProvider
-            ?: defaultRichTextThemeConfiguration.contentColorProvider,
+            ?: RichTextThemeConfiguration.Default.contentColorProvider,
           contentColorBackProvider = contentColorBackProvider
-            ?: defaultRichTextThemeConfiguration.contentColorBackProvider,
+            ?: RichTextThemeConfiguration.Default.contentColorBackProvider,
         )
   ) {
     content()

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/RichTextString.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/string/RichTextString.kt
@@ -296,18 +296,7 @@ public data class RichTextString internal constructor(
     ) {
       val tag = randomUUID()
       formatObjects["inline:$tag"] = content
-
-      // Resets the style to defaults.
-      //
-      // This is important for inline content because the user might set a global line height
-      // via ProvideTextStyle(TextStyle(lineHeight = 1.3.em)) { ... }
-      // Once set, the line height is fixed for all objects and any inline content (like images)
-      // will expand over the text. Since this is not a text section, it should be fine.
-      //
-      // Fixed line height seems to only affect mobile.
-      builder.pushStyle(ParagraphStyle())
       builder.appendInlineContent(tag, alternateText)
-      builder.pop()
     }
 
     /**


### PR DESCRIPTION
InlineContent is not supposed to have its own ParagraphStyle. That kind of workaround makes the content essentially "non-inline". Each inline content composable gets its own Paragraph. Instead, we should address the root of the problem which stems from the fact that default Material3 theming adds LineHeight by default.

Sample project now uses Material3 and overrides the default LineHeight to `TextUnit.Unspecified` in its theming. Inline content strictly respecting the line height argument should be addressed by the Compose team.