### PR TITLE
Fixes linkClickHandler not working in inner uses of BasicRichText. 

### DIFF
--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
@@ -216,7 +216,7 @@ private val sampleMarkdown = """
   + Or pluses
 <!-- -->
   2. Ordered list starting with `2.`
-  3. Another item
+  3. Another item with [link](https://www.google.com)
 <!-- -->
   0. Ordered list starting with `0.`
 <!-- -->

--- a/richtext-ui-material/src/commonMain/kotlin/com/halilibo/richtext/ui/material/RichText.kt
+++ b/richtext-ui-material/src/commonMain/kotlin/com/halilibo/richtext/ui/material/RichText.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.Modifier
 import com.halilibo.richtext.ui.BasicRichText
 import com.halilibo.richtext.ui.LinkClickHandler
+import com.halilibo.richtext.ui.LocalLinkClickHandler
 import com.halilibo.richtext.ui.RichTextScope
 import com.halilibo.richtext.ui.RichTextStyle
 import com.halilibo.richtext.ui.RichTextThemeProvider
@@ -28,12 +29,13 @@ public fun RichText(
   children: @Composable RichTextScope.() -> Unit
 ) {
   RichTextMaterialTheme {
-    BasicRichText(
-      modifier = modifier,
-      style = style,
-      linkClickHandler = linkClickHandler,
-      children = children
-    )
+    CompositionLocalProvider(LocalLinkClickHandler provides linkClickHandler) {
+      BasicRichText(
+        modifier = modifier,
+        style = style,
+        children = children
+      )
+    }
   }
 }
 

--- a/richtext-ui-material3/src/commonMain/kotlin/com/halilibo/richtext/ui/material3/RichText.kt
+++ b/richtext-ui-material3/src/commonMain/kotlin/com/halilibo/richtext/ui/material3/RichText.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.Modifier
 import com.halilibo.richtext.ui.BasicRichText
 import com.halilibo.richtext.ui.LinkClickHandler
+import com.halilibo.richtext.ui.LocalLinkClickHandler
 import com.halilibo.richtext.ui.RichTextScope
 import com.halilibo.richtext.ui.RichTextStyle
 import com.halilibo.richtext.ui.RichTextThemeProvider
@@ -28,12 +29,13 @@ public fun RichText(
   children: @Composable RichTextScope.() -> Unit
 ) {
   RichTextMaterialTheme {
-    BasicRichText(
-      modifier = modifier,
-      style = style,
-      linkClickHandler = linkClickHandler,
-      children = children
-    )
+    CompositionLocalProvider(LocalLinkClickHandler provides linkClickHandler) {
+      BasicRichText(
+        modifier = modifier,
+        style = style,
+        children = children
+      )
+    }
   }
 }
 

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/BasicRichText.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/BasicRichText.kt
@@ -16,21 +16,18 @@ import androidx.compose.ui.platform.LocalDensity
 public fun BasicRichText(
   modifier: Modifier = Modifier,
   style: RichTextStyle? = null,
-  linkClickHandler: LinkClickHandler? = null,
   children: @Composable RichTextScope.() -> Unit
 ) {
   with(RichTextScope) {
     RestartListLevel {
       WithStyle(style) {
-        CompositionLocalProvider(LocalLinkClickHandler provides linkClickHandler) {
-          val resolvedStyle = currentRichTextStyle.resolveDefaults()
-          val blockSpacing = with(LocalDensity.current) {
-            resolvedStyle.paragraphSpacing!!.toDp()
-          }
+        val resolvedStyle = currentRichTextStyle.resolveDefaults()
+        val blockSpacing = with(LocalDensity.current) {
+          resolvedStyle.paragraphSpacing!!.toDp()
+        }
 
-          Column(modifier = modifier, verticalArrangement = spacedBy(blockSpacing)) {
-            children()
-          }
+        Column(modifier = modifier, verticalArrangement = spacedBy(blockSpacing)) {
+          children()
         }
       }
     }

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/LinkClickHandler.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/LinkClickHandler.kt
@@ -1,5 +1,7 @@
 package com.halilibo.richtext.ui
 
+import androidx.compose.runtime.CompositionLocal
+import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
 
 /**
@@ -14,4 +16,4 @@ public fun interface LinkClickHandler {
  * An internal composition local to pass through LinkClickHandler from root [BasicRichText]
  * composable to children that render links.
  */
-public val LocalLinkClickHandler = compositionLocalOf<LinkClickHandler?> { null }
+public val LocalLinkClickHandler: ProvidableCompositionLocal<LinkClickHandler?> = compositionLocalOf<LinkClickHandler?> { null }

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/LinkClickHandler.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/LinkClickHandler.kt
@@ -14,4 +14,4 @@ public fun interface LinkClickHandler {
  * An internal composition local to pass through LinkClickHandler from root [BasicRichText]
  * composable to children that render links.
  */
-internal val LocalLinkClickHandler = compositionLocalOf<LinkClickHandler?> { null }
+public val LocalLinkClickHandler = compositionLocalOf<LinkClickHandler?> { null }


### PR DESCRIPTION
linkClickHandler is not passing around when new `BasicRichText`s are instantiated. 

I am not sure if this is the correct way of solving it, but this applies the same LocalLinkClickHandler to the entire hierarchy of nodes, not just the first level. It seems better than passing it around to new instances of BasicRichTexts. 

FYI, in the demo, the click worked but wasn't handled by the custom handler. It was using the default `LocalUriHandler.current`. 