### PR TITLE
Restructures MarkdownParseOptions to expose extension selectors.

### DIFF
--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/LazyMarkdownSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/LazyMarkdownSample.kt
@@ -61,9 +61,10 @@ import com.halilibo.richtext.ui.resolveDefaults
     )
   }
   LaunchedEffect(isAutolinkEnabled) {
-    markdownParseOptions = markdownParseOptions.copy(
-      autolink = isAutolinkEnabled
-    )
+    markdownParseOptions = if (isAutolinkEnabled)
+      MarkdownParseOptions.MarkdownWithLinks
+    else
+      MarkdownParseOptions.MarkdownOnly
   }
 
   val colors = if (isDarkModeEnabled) darkColorScheme() else lightColorScheme()

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
@@ -61,9 +61,10 @@ import com.halilibo.richtext.ui.resolveDefaults
     )
   }
   LaunchedEffect(isAutolinkEnabled) {
-    markdownParseOptions = markdownParseOptions.copy(
-      autolink = isAutolinkEnabled
-    )
+    markdownParseOptions = if (isAutolinkEnabled)
+      MarkdownParseOptions.MarkdownWithLinks
+    else
+      MarkdownParseOptions.MarkdownOnly
   }
 
   val colors = if (isDarkModeEnabled) darkColorScheme() else lightColorScheme()

--- a/docs/richtext-commonmark.md
+++ b/docs/richtext-commonmark.md
@@ -97,7 +97,11 @@ Passing `MarkdownParseOptions` into either `Markdown` composable or `CommonmarkA
 
 ```kotlin
 val markdownParseOptions = MarkdownParseOptions(
-  autolink = false
+  listOfNotNull(
+    TablesExtension.create(),
+    StrikethroughExtension.create(),
+    AutolinkExtension.create()
+  )
 )
 
 Markdown(

--- a/richtext-commonmark/src/commonJvmAndroid/kotlin/com/halilibo/richtext/commonmark/AstNodeConvert.kt
+++ b/richtext-commonmark/src/commonJvmAndroid/kotlin/com/halilibo/richtext/commonmark/AstNodeConvert.kt
@@ -187,13 +187,7 @@ public actual class CommonmarkAstNodeParser actual constructor(
 ) {
 
   private val parser = Parser.builder()
-    .extensions(
-      listOfNotNull(
-        TablesExtension.create(),
-        StrikethroughExtension.create(),
-        if (options.autolink) AutolinkExtension.create() else null
-      )
-    )
+    .extensions(options.extensions)
     .build()
 
   public actual fun parse(text: String): AstNode {

--- a/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/commonmark/MarkdownParseOptions.kt
+++ b/richtext-commonmark/src/commonMain/kotlin/com/halilibo/richtext/commonmark/MarkdownParseOptions.kt
@@ -1,16 +1,32 @@
 package com.halilibo.richtext.commonmark
 
+import org.commonmark.Extension
+import org.commonmark.ext.autolink.AutolinkExtension
+import org.commonmark.ext.gfm.strikethrough.StrikethroughExtension
+import org.commonmark.ext.gfm.tables.TablesExtension
+
 /**
  * Allows configuration of the Markdown parser
  *
  * @param autolink Detect plain text links and turn them into Markdown links.
  */
-public data class MarkdownParseOptions(
-  val autolink: Boolean
-) {
+public data class MarkdownParseOptions(val extensions: List<Extension>) {
   public companion object {
-    public val Default: MarkdownParseOptions = MarkdownParseOptions(
-      autolink = true
+    public val MarkdownWithLinks: MarkdownParseOptions = MarkdownParseOptions(
+      listOfNotNull(
+        TablesExtension.create(),
+        StrikethroughExtension.create(),
+        AutolinkExtension.create()
+      )
     )
+
+    public val MarkdownOnly: MarkdownParseOptions = MarkdownParseOptions(
+      listOfNotNull(
+        TablesExtension.create(),
+        StrikethroughExtension.create()
+      )
+    )
+
+    public val Default: MarkdownParseOptions = MarkdownWithLinks
   }
 }


### PR DESCRIPTION
I have a need to add my own custom extensions to the parser and thought this could be a good generalization for everyone else. 

This opens up `MarkdownParseOptions` to some flexibility in enabling or disabling extensions. 