### PR TITLE
Fix #150

### DIFF
--- a/desktop-sample/src/main/kotlin/com/halilibo/richtext/desktop/MarkdownSampleApp.kt
+++ b/desktop-sample/src/main/kotlin/com/halilibo/richtext/desktop/MarkdownSampleApp.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.text.selection.DisableSelection
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
@@ -70,7 +71,7 @@ fun main(): Unit = singleWindowApplication(
       )
     ) {
       SelectionContainer {
-        var text by remember { mutableStateOf(sampleMarkdown) }
+        val state = rememberTextFieldState(sampleMarkdown)
         Row(
           modifier = Modifier
             .padding(32.dp)
@@ -80,9 +81,7 @@ fun main(): Unit = singleWindowApplication(
           Column(modifier = Modifier.weight(1f)) {
             RichTextStyleConfig(richTextStyle = richTextStyle, onChanged = { richTextStyle = it })
             BasicTextField(
-              value = text,
-              onValueChange = { text = it },
-              maxLines = Int.MAX_VALUE,
+              state = state,
               modifier = Modifier
                 .fillMaxHeight()
                 .background(Color.LightGray)
@@ -111,7 +110,7 @@ fun main(): Unit = singleWindowApplication(
                   modifier = Modifier.verticalScroll(rememberScrollState()),
                   style = richTextStyle,
                 ) {
-                  Markdown(content = text)
+                  Markdown(content = state.text.toString())
                 }
               } else {
                 val parser = remember { CommonmarkAstNodeParser() }

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
@@ -275,8 +275,12 @@ private val LocalListLevel = compositionLocalOf { 0 }
     val widestItem = itemPlaceables.maxByOrNull { it.width }!!
 
     val listWidth = widestPrefix.width + widestItem.width
-    val listHeight = itemPlaceables.sumOf { it.height } +
+    val itemsHeight = itemPlaceables.sumOf { it.height } +
         (itemPlaceables.size - 1) * itemSpacing.roundToPx()
+    val prefixesHeight = prefixPlaceables.sumOf { it.height } +
+        (prefixPlaceables.size - 1) * itemSpacing.roundToPx()
+
+    val listHeight = maxOf(itemsHeight, prefixesHeight)
     layout(listWidth, listHeight) {
       var y = 0
 


### PR DESCRIPTION
When calculating the height for PrefixListLayout, we were only adding up the heights of each item. When the items is empty or small, the reported height in the final layout would be too small, causing composables under it to draw over the list layout and prefixes.

The fix is to also calculate the total height of prefixes and compare with the items height. The bigger of them should be reported as the height of the list.