### PR TITLE
Correct prefix measurement logic in FormattedList

### DIFF
--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/FormattedList.kt
@@ -259,7 +259,7 @@ private val LocalListLevel = compositionLocalOf { 0 }
 
     // Measure the prefixes first.
     val prefixPlaceables = prefixMeasureables.map { marker ->
-      marker.measure(Constraints())
+      marker.measure(constraints)
     }
       .toList()
     val widestPrefix = prefixPlaceables.maxByOrNull { it.width }!!


### PR DESCRIPTION
Fix measurement of prefix placeables by using the given constraints. Using new constraints could create UI issues when adding an height constraint on the RichText composable. 

This can easily be reproduced using the sample app and adding `.heightIn(max = 150.dp)` at line 129. Without the correction, the prefixes are drawn even if the corresponding item is out of the view.