### PR TITLE
Fix StackOverflowError in recursive AST conversion

### DIFF
--- a/richtext-commonmark/src/commonJvmAndroid/kotlin/com/halilibo/richtext/commonmark/AstNodeConvert.kt
+++ b/richtext-commonmark/src/commonJvmAndroid/kotlin/com/halilibo/richtext/commonmark/AstNodeConvert.kt
@@ -70,7 +70,104 @@ import org.commonmark.node.ThematicBreak
 import org.commonmark.parser.Parser
 
 /**
- * Converts common-markdown tree to AstNode tree in a recursive fashion.
+ * Holds the data for a pending conversion task in the iterative tree traversal.
+ */
+private class ConvertWorkItem(
+  val startNode: Node,
+  val parentAstNode: AstNode?,
+  val initialPrev: AstNode?,
+  val onFirstCreated: (AstNode?) -> Unit
+)
+
+/**
+ * Maps a CommonMark [Node] to its corresponding [AstNodeType].
+ * Returns null for unrecognized node types (CustomNode, CustomBlock, etc.).
+ */
+private fun convertNodeType(node: Node): AstNodeType? = when (node) {
+  is BlockQuote -> AstBlockQuote
+  is BulletList -> AstUnorderedList(bulletMarker = node.bulletMarker)
+  is Code -> AstCode(literal = node.literal)
+  is Document -> AstDocument
+  is Emphasis -> AstEmphasis(delimiter = node.openingDelimiter)
+  is FencedCodeBlock -> AstFencedCodeBlock(
+    literal = node.literal,
+    fenceChar = node.fenceChar,
+    fenceIndent = node.fenceIndent,
+    fenceLength = node.fenceLength,
+    info = node.info
+  )
+  is HardLineBreak -> AstHardLineBreak
+  is Heading -> AstHeading(
+    level = node.level
+  )
+  is ThematicBreak -> AstThematicBreak
+  is HtmlInline -> AstHtmlInline(
+    literal = node.literal
+  )
+  is HtmlBlock -> AstHtmlBlock(
+    literal = node.literal
+  )
+  is Image -> {
+    if (node.destination == null) {
+      null
+    }
+    else {
+      AstImage(
+        title = node.title ?: "",
+        destination = node.destination
+      )
+    }
+  }
+  is IndentedCodeBlock -> AstIndentedCodeBlock(
+    literal = node.literal
+  )
+  is Link -> AstLink(
+    title = node.title ?: "",
+    destination = node.destination
+  )
+  is ListItem -> AstListItem
+  is OrderedList -> AstOrderedList(
+    startNumber = node.startNumber,
+    delimiter = node.delimiter
+  )
+  is Paragraph -> AstParagraph
+  is SoftLineBreak -> AstSoftLineBreak
+  is StrongEmphasis -> AstStrongEmphasis(
+    delimiter = node.openingDelimiter
+  )
+  is Text -> AstText(
+    literal = node.literal
+  )
+  is LinkReferenceDefinition -> AstLinkReferenceDefinition(
+    title = node.title ?: "",
+    destination = node.destination,
+    label = node.label
+  )
+  is TableBlock -> AstTableRoot
+  is TableHead -> AstTableHeader
+  is TableBody -> AstTableBody
+  is TableRow -> AstTableRow
+  is TableCell -> AstTableCell(
+    header = node.isHeader,
+    alignment = when (node.alignment) {
+      LEFT -> AstTableCellAlignment.LEFT
+      CENTER -> AstTableCellAlignment.CENTER
+      RIGHT -> AstTableCellAlignment.RIGHT
+      null -> AstTableCellAlignment.LEFT
+      else -> AstTableCellAlignment.LEFT
+    }
+  )
+  is Strikethrough -> AstStrikethrough(
+    node.openingDelimiter
+  )
+  is CustomNode -> null
+  is CustomBlock -> null
+  else -> null
+}
+
+/**
+ * Converts common-markdown tree to AstNode tree iteratively using an explicit stack,
+ * avoiding StackOverflowError on deeply nested or long markdown documents.
  */
 internal fun convert(
   node: Node?,
@@ -79,107 +176,60 @@ internal fun convert(
 ): AstNode? {
   node ?: return null
 
-  val nodeLinks = AstNodeLinks(
-    parent = parentNode,
-    previous = previousNode,
-  )
+  var result: AstNode? = null
+  val stack = ArrayDeque<ConvertWorkItem>()
+  stack.addLast(ConvertWorkItem(node, parentNode, previousNode) { result = it })
 
-  val newNodeType: AstNodeType? = when (node) {
-    is BlockQuote -> AstBlockQuote
-    is BulletList -> AstUnorderedList(bulletMarker = node.bulletMarker)
-    is Code -> AstCode(literal = node.literal)
-    is Document -> AstDocument
-    is Emphasis -> AstEmphasis(delimiter = node.openingDelimiter)
-    is FencedCodeBlock -> AstFencedCodeBlock(
-      literal = node.literal,
-      fenceChar = node.fenceChar,
-      fenceIndent = node.fenceIndent,
-      fenceLength = node.fenceLength,
-      info = node.info
-    )
-    is HardLineBreak -> AstHardLineBreak
-    is Heading -> AstHeading(
-      level = node.level
-    )
-    is ThematicBreak -> AstThematicBreak
-    is HtmlInline -> AstHtmlInline(
-      literal = node.literal
-    )
-    is HtmlBlock -> AstHtmlBlock(
-      literal = node.literal
-    )
-    is Image -> {
-      if (node.destination == null) {
-        null
+  while (stack.isNotEmpty()) {
+    val item = stack.removeLast()
+
+    var prev: AstNode? = null
+    var firstCreated: AstNode? = null
+    var cmNode: Node? = item.startNode
+    var nullTypeNode: Node? = null
+
+    // Iterate through siblings instead of recursing
+    while (cmNode != null) {
+      val nodeType = convertNodeType(cmNode)
+      val newNode = nodeType?.let {
+        AstNode(it, AstNodeLinks(
+          parent = item.parentAstNode,
+          previous = prev ?: item.initialPrev
+        ))
       }
-      else {
-        AstImage(
-          title = node.title ?: "",
-          destination = node.destination
-        )
+
+      if (newNode != null) {
+        if (firstCreated == null) firstCreated = newNode
+        prev?.links?.next = newNode
+
+        // Push child processing onto the explicit stack instead of recursing
+        val child = cmNode.firstChild
+        if (child != null) {
+          stack.addLast(ConvertWorkItem(child, newNode, null) { newNode.links.firstChild = it })
+        }
+
+        prev = newNode
+        cmNode = cmNode.next
+      } else {
+        // Unrecognized node type — stop sibling chain (preserves original behavior)
+        nullTypeNode = cmNode
+        cmNode = null
       }
     }
-    is IndentedCodeBlock -> AstIndentedCodeBlock(
-      literal = node.literal
-    )
-    is Link -> AstLink(
-      title = node.title ?: "",
-      destination = node.destination
-    )
-    is ListItem -> AstListItem
-    is OrderedList -> AstOrderedList(
-      startNumber = node.startNumber,
-      delimiter = node.delimiter
-    )
-    is Paragraph -> AstParagraph
-    is SoftLineBreak -> AstSoftLineBreak
-    is StrongEmphasis -> AstStrongEmphasis(
-      delimiter = node.openingDelimiter
-    )
-    is Text -> AstText(
-      literal = node.literal
-    )
-    is LinkReferenceDefinition -> AstLinkReferenceDefinition(
-      title = node.title ?: "",
-      destination = node.destination,
-      label = node.label
-    )
-    is TableBlock -> AstTableRoot
-    is TableHead -> AstTableHeader
-    is TableBody -> AstTableBody
-    is TableRow -> AstTableRow
-    is TableCell -> AstTableCell(
-      header = node.isHeader,
-      alignment = when (node.alignment) {
-        LEFT -> AstTableCellAlignment.LEFT
-        CENTER -> AstTableCellAlignment.CENTER
-        RIGHT -> AstTableCellAlignment.RIGHT
-        null -> AstTableCellAlignment.LEFT
-        else -> AstTableCellAlignment.LEFT
+
+    // Set lastChild on the parent, matching the original recursive behavior
+    if (nullTypeNode != null) {
+      if (nullTypeNode.next == null) {
+        item.parentAstNode?.links?.lastChild = null
       }
-    )
-    is Strikethrough -> AstStrikethrough(
-      node.openingDelimiter
-    )
-    is CustomNode -> null
-    is CustomBlock -> null
-    else -> null
+    } else {
+      item.parentAstNode?.links?.lastChild = prev
+    }
+
+    item.onFirstCreated(firstCreated)
   }
 
-  val newNode = newNodeType?.let {
-    AstNode(newNodeType, nodeLinks)
-  }
-
-  if (newNode != null) {
-    newNode.links.firstChild = convert(node.firstChild, parentNode = newNode, previousNode = null)
-    newNode.links.next = convert(node.next, parentNode = parentNode, previousNode = newNode)
-  }
-
-  if (node.next == null) {
-    parentNode?.links?.lastChild = newNode
-  }
-
-  return newNode
+  return result
 }
 
 public actual class CommonmarkAstNodeParser actual constructor(

--- a/richtext-commonmark/src/commonJvmAndroidTest/kotlin/com/halilibo/richtext/commonmark/AstNodeConvertKtTest.kt
+++ b/richtext-commonmark/src/commonJvmAndroidTest/kotlin/com/halilibo/richtext/commonmark/AstNodeConvertKtTest.kt
@@ -1,14 +1,32 @@
 package com.halilibo.richtext.markdown
 
+import com.halilibo.richtext.commonmark.CommonMarkdownParseOptions
+import com.halilibo.richtext.commonmark.CommonmarkAstNodeParser
 import com.halilibo.richtext.commonmark.convert
+import com.halilibo.richtext.markdown.node.AstBlockQuote
+import com.halilibo.richtext.markdown.node.AstDocument
+import com.halilibo.richtext.markdown.node.AstHeading
 import com.halilibo.richtext.markdown.node.AstImage
 import com.halilibo.richtext.markdown.node.AstNode
 import com.halilibo.richtext.markdown.node.AstNodeLinks
+import com.halilibo.richtext.markdown.node.AstParagraph
+import com.halilibo.richtext.markdown.node.AstText
+import org.commonmark.node.Document
 import org.commonmark.node.Image
+import org.commonmark.node.Paragraph
+import org.commonmark.node.Text
 import org.junit.Test
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlin.test.fail
 
 internal class AstNodeConvertKtTest {
+
+  private val parser = CommonmarkAstNodeParser(CommonMarkdownParseOptions.Default)
 
   @Test
   fun `when image without title is converted, then the content description is empty`() {
@@ -25,4 +43,169 @@ internal class AstNodeConvertKtTest {
       actual = result
     )
   }
+
+  @Test
+  fun `tree links are correctly wired for a document with siblings`() {
+    val root = parser.parse("# Heading\n\nParagraph text")
+
+    // Root should be a Document
+    assertEquals(AstDocument, root.type)
+    assertNull(root.links.parent)
+
+    // First child should be the heading
+    val heading = root.links.firstChild
+    assertNotNull(heading)
+    assertEquals(AstHeading(level = 1), heading.type)
+    assertSame(root, heading.links.parent)
+    assertNull(heading.links.previous)
+
+    // Second child should be the paragraph
+    val paragraph = heading.links.next
+    assertNotNull(paragraph)
+    assertEquals(AstParagraph, paragraph.type)
+    assertSame(root, paragraph.links.parent)
+    assertSame(heading, paragraph.links.previous)
+    assertNull(paragraph.links.next)
+
+    // lastChild should point to the paragraph
+    assertSame(paragraph, root.links.lastChild)
+  }
+
+  @Test
+  fun `tree links are correctly wired for nested structures`() {
+    val root = parser.parse("> quoted text")
+
+    val blockquote = root.links.firstChild
+    assertNotNull(blockquote)
+    assertEquals(AstBlockQuote, blockquote.type)
+    assertSame(root, blockquote.links.parent)
+
+    val paragraph = blockquote.links.firstChild
+    assertNotNull(paragraph)
+    assertEquals(AstParagraph, paragraph.type)
+    assertSame(blockquote, paragraph.links.parent)
+
+    val text = paragraph.links.firstChild
+    assertNotNull(text)
+    assertEquals(AstText(literal = "quoted text"), text.type)
+    assertSame(paragraph, text.links.parent)
+  }
+
+  @Test
+  fun `document with many sibling paragraphs does not overflow`() {
+    // 2000 paragraphs would cause ~2000 frames of sibling recursion
+    val markdown = (1..2000).joinToString("\n\n") { "Paragraph $it" }
+    val root = parser.parse(markdown)
+
+    assertEquals(AstDocument, root.type)
+
+    // Walk the sibling chain and count paragraphs
+    var count = 0
+    var node = root.links.firstChild
+    while (node != null) {
+      assertEquals(AstParagraph, node.type)
+      count++
+      node = node.links.next
+    }
+    assertEquals(2000, count)
+
+    // lastChild should be the final paragraph
+    assertNotNull(root.links.lastChild)
+    assertNull(root.links.lastChild!!.links.next)
+  }
+
+  @Test
+  fun `deeply nested blockquotes do not overflow`() {
+    // 500 levels of nested blockquotes would cause ~500 frames of child recursion
+    val markdown = ">".repeat(500) + " deep text"
+    val root = parser.parse(markdown)
+
+    assertEquals(AstDocument, root.type)
+
+    // Walk down the child chain counting blockquotes
+    var depth = 0
+    var node = root.links.firstChild
+    while (node != null && node.type is AstBlockQuote) {
+      depth++
+      node = node.links.firstChild
+    }
+    assertEquals(500, depth)
+
+    // The innermost blockquote should contain a paragraph with text
+    assertNotNull(node)
+    assertEquals(AstParagraph, node.type)
+  }
+
+  /**
+   * Proves that the sibling chain depth we test would overflow a recursive implementation
+   * on a constrained thread stack (similar to Android's ~1MB default), while our iterative
+   * convert() handles it without issue.
+   */
+  @Test
+  fun `convert handles long sibling chains that would overflow a recursive implementation`() {
+    val siblingCount = 5000
+    // Build a CommonMark tree directly: Document -> Paragraph("1") -> Paragraph("2") -> ...
+    val doc = Document()
+    for (i in 1..siblingCount) {
+      val para = Paragraph()
+      para.appendChild(Text("$i"))
+      doc.appendChild(para)
+    }
+
+    val stackSize = 256L * 1024 // 256KB — smaller than Android's default ~1MB
+
+    // First, prove this stack size is too small for equivalent-depth recursion.
+    // A simple recursive chain of siblingCount depth will overflow.
+    val recursionOverflowed = AtomicReference<Boolean>(false)
+    val recursionThread = Thread(null, {
+      try {
+        countRecursively(siblingCount)
+      } catch (_: StackOverflowError) {
+        recursionOverflowed.set(true)
+      }
+    }, "recursion-test", stackSize)
+    recursionThread.start()
+    recursionThread.join()
+    assertTrue(
+      recursionOverflowed.get(),
+      "Expected StackOverflowError for $siblingCount recursive calls on ${stackSize / 1024}KB stack"
+    )
+
+    // Now prove our iterative convert() handles the same depth on the same stack size.
+    val convertError = AtomicReference<Throwable?>(null)
+    val convertResult = AtomicReference<AstNode?>(null)
+    val convertThread = Thread(null, {
+      try {
+        convertResult.set(convert(doc))
+      } catch (e: Throwable) {
+        convertError.set(e)
+      }
+    }, "convert-test", stackSize)
+    convertThread.start()
+    convertThread.join()
+
+    val error = convertError.get()
+    if (error != null) {
+      fail("convert() should not throw on a long sibling chain, but threw: $error")
+    }
+
+    val root = convertResult.get()
+    assertNotNull(root, "convert() should return a non-null root")
+    assertEquals(AstDocument, root.type)
+
+    // Verify the full sibling chain was converted
+    var count = 0
+    var node = root.links.firstChild
+    while (node != null) {
+      count++
+      node = node.links.next
+    }
+    assertEquals(siblingCount, count)
+  }
+}
+
+/** Simple recursive function that recurses [n] times to demonstrate stack overflow. */
+private fun countRecursively(n: Int): Int {
+  if (n <= 0) return 0
+  return 1 + countRecursively(n - 1)
 }


### PR DESCRIPTION
## Summary

The `convert()` function in `AstNodeConvert.kt` converts a CommonMark `Node` tree into an `AstNode` tree using recursion in two directions — the sibling chain (`node.next`) and the child chain (`node.firstChild`). Both recurse without bound, causing `StackOverflowError` crashes in production on Android's ~1MB default thread stack when documents contain many sequential blocks or deeply nested structures.

**Crashlytics stack trace:**
```
java.lang.StackOverflowError: stack size 1037KB
  at com.halilibo.richtext.markdown.node.AstNode.<init> (AstNode.kt:4)
  at com.halilibo.richtext.commonmark.AstNodeConvertKt.convert (AstNodeConvert.kt:170)
  at com.halilibo.richtext.commonmark.AstNodeConvertKt.convert (AstNodeConvert.kt:174)
  at com.halilibo.richtext.commonmark.AstNodeConvertKt.convert (AstNodeConvert.kt:175)
  ... (hundreds of frames)
```

**Changes:**
- Replaced the recursive `convert()` with an iterative implementation: siblings are traversed in a `while` loop, and child processing is pushed onto an explicit `ArrayDeque` stack
- Extracted the node-type mapping `when` block into a private `convertNodeType()` helper (no logic changes)
- The function signature and external behavior are unchanged — the produced `AstNode` tree is identical (all `AstNodeLinks` — `parent`, `firstChild`, `lastChild`, `next`, `previous` — are wired up the same way)

**Tests added:**
- Tree link correctness for documents with siblings (parent/previous/next/lastChild)
- Tree link correctness for nested structures (blockquote → paragraph → text)
- 2,000 sibling paragraphs complete without overflow
- 500 levels of nested blockquotes complete without overflow
- Constrained-stack proof: builds a 5,000-sibling CommonMark tree and runs `convert()` on a thread with a 256KB stack — first proves that equivalent-depth recursion overflows, then proves the iterative `convert()` handles it

## Test plan

- [x] `./gradlew :richtext-commonmark:allTests` passes (6 tests, 0 failures)
- [x] Verified the old recursive implementation fails 2 of the new tests (`StackOverflowError` on 2,000 siblings; assertion failure on the constrained-stack test)
- [x] Existing test (`image without title`) continues to pass unchanged