### PR TITLE
Restore minSdk in AGP 9 KMP-library convention plugin (fixes #188)

### DIFF
--- a/buildSrc/src/main/kotlin/richtext-kmp-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/richtext-kmp-library.gradle.kts
@@ -39,6 +39,7 @@ kotlin {
 
   android {
     compileSdk = 36
+    minSdk = AndroidConfiguration.minSdk
 
     compilerOptions {
       jvmTarget.set(JvmTarget.JVM_11)


### PR DESCRIPTION
Fixes #188.

The AGP 9 migration in 04e52ea3 replaced `com.android.library`'s `defaultConfig { minSdk = 21; targetSdk = compileSdk }` with `com.android.kotlin.multiplatform.library`'s `kotlin.android { compileSdk = 36 }` block, but didn't carry over the `minSdk` assignment. The `import AndroidConfiguration.minSdk` line is still in the file, unused — pretty clearly a copy/paste miss.

Since then the AARs ship with `<uses-sdk android:minSdkVersion="1" />`, which trips the manifest merger's legacy-target-sdk rule and implies `READ_PHONE_STATE`, `READ_EXTERNAL_STORAGE`, `WRITE_EXTERNAL_STORAGE` into every consuming app — Play Console flags those as Sensitive Permissions.

The fix uses the already-imported `AndroidConfiguration.minSdk` (= 23). `targetSdk` doesn't apply to library modules in the new KMP plugin, so it's left alone. Other projects on this plugin (okhttp, thunderbird-android) set `minSdk` on `kotlin.android { ... }` the same way.

Verified locally: all five published AARs now have `<uses-sdk android:minSdkVersion="23" />`, and a downstream app's merged manifest no longer contains the implied permissions.
